### PR TITLE
Add unit tests for model builders and equality

### DIFF
--- a/cii-messaging-parent/cii-model/src/test/java/com/cii/messaging/model/AddressTest.java
+++ b/cii-messaging-parent/cii-model/src/test/java/com/cii/messaging/model/AddressTest.java
@@ -1,0 +1,56 @@
+package com.cii.messaging.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AddressTest {
+
+    @Test
+    void builderShouldSetFields() {
+        Address address = Address.builder()
+                .street("123 Main St")
+                .city("Springfield")
+                .postalCode("12345")
+                .countryCode("US")
+                .countryName("United States")
+                .build();
+
+        assertEquals("123 Main St", address.getStreet());
+        assertEquals("Springfield", address.getCity());
+        assertEquals("12345", address.getPostalCode());
+        assertEquals("US", address.getCountryCode());
+        assertEquals("United States", address.getCountryName());
+    }
+
+    @Test
+    void equalsAndHashCodeShouldWork() {
+        Address address1 = Address.builder()
+                .street("123 Main St")
+                .city("Springfield")
+                .postalCode("12345")
+                .countryCode("US")
+                .countryName("United States")
+                .build();
+
+        Address address2 = Address.builder()
+                .street("123 Main St")
+                .city("Springfield")
+                .postalCode("12345")
+                .countryCode("US")
+                .countryName("United States")
+                .build();
+
+        Address address3 = Address.builder()
+                .street("456 Elm St")
+                .city("Shelbyville")
+                .postalCode("54321")
+                .countryCode("CA")
+                .countryName("Canada")
+                .build();
+
+        assertEquals(address1, address2);
+        assertEquals(address1.hashCode(), address2.hashCode());
+        assertNotEquals(address1, address3);
+    }
+}

--- a/cii-messaging-parent/cii-model/src/test/java/com/cii/messaging/model/CIIMessageTest.java
+++ b/cii-messaging-parent/cii-model/src/test/java/com/cii/messaging/model/CIIMessageTest.java
@@ -1,0 +1,149 @@
+package com.cii.messaging.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CIIMessageTest {
+
+    private DocumentHeader sampleHeader() {
+        PaymentTerms terms = PaymentTerms.builder()
+                .description("Net 30")
+                .dueDate(LocalDate.of(2023, 6, 15))
+                .paymentMeansCode("30")
+                .accountNumber("123456")
+                .accountName("Main Account")
+                .financialInstitution("Bank")
+                .build();
+
+        DeliveryInformation delivery = DeliveryInformation.builder()
+                .deliveryDate(LocalDate.of(2023, 5, 20))
+                .deliveryLocationId("LOC1")
+                .deliveryAddress(Address.builder()
+                        .street("123 Main St")
+                        .city("Springfield")
+                        .postalCode("12345")
+                        .countryCode("US")
+                        .countryName("United States")
+                        .build())
+                .deliveryPartyName("John Doe")
+                .build();
+
+        return DocumentHeader.builder()
+                .documentNumber("INV-1")
+                .documentDate(LocalDate.of(2023, 5, 1))
+                .buyerReference("BUYER")
+                .sellerReference("SELLER")
+                .contractReference("CONTRACT")
+                .currency("USD")
+                .paymentTerms(terms)
+                .delivery(delivery)
+                .build();
+    }
+
+    private LineItem sampleLineItem() {
+        return LineItem.builder()
+                .lineNumber("1")
+                .productId("P001")
+                .description("Product 1")
+                .quantity(new BigDecimal("2"))
+                .unitCode("EA")
+                .unitPrice(new BigDecimal("10"))
+                .lineAmount(new BigDecimal("20"))
+                .taxRate(new BigDecimal("0.2"))
+                .taxCategory("VAT")
+                .build();
+    }
+
+    private TotalsInformation sampleTotals() {
+        return TotalsInformation.builder()
+                .lineTotalAmount(new BigDecimal("20"))
+                .taxBasisAmount(new BigDecimal("20"))
+                .taxTotalAmount(new BigDecimal("4"))
+                .grandTotalAmount(new BigDecimal("24"))
+                .prepaidAmount(new BigDecimal("0"))
+                .duePayableAmount(new BigDecimal("24"))
+                .build();
+    }
+
+    @Test
+    void builderShouldSetFields() {
+        DocumentHeader header = sampleHeader();
+        LineItem lineItem = sampleLineItem();
+        TotalsInformation totals = sampleTotals();
+        LocalDateTime timestamp = LocalDateTime.of(2023, 5, 1, 12, 0);
+
+        CIIMessage message = CIIMessage.builder()
+                .messageId("MSG1")
+                .messageType(MessageType.INVOICE)
+                .creationDateTime(timestamp)
+                .senderPartyId("SENDER")
+                .receiverPartyId("RECEIVER")
+                .header(header)
+                .lineItems(List.of(lineItem))
+                .totals(totals)
+                .build();
+
+        assertEquals("MSG1", message.getMessageId());
+        assertEquals(MessageType.INVOICE, message.getMessageType());
+        assertEquals(timestamp, message.getCreationDateTime());
+        assertEquals("SENDER", message.getSenderPartyId());
+        assertEquals("RECEIVER", message.getReceiverPartyId());
+        assertEquals(header, message.getHeader());
+        assertEquals(List.of(lineItem), message.getLineItems());
+        assertEquals(totals, message.getTotals());
+    }
+
+    @Test
+    void equalsAndHashCodeShouldWork() {
+        DocumentHeader header1 = sampleHeader();
+        DocumentHeader header2 = sampleHeader();
+        LineItem item1 = sampleLineItem();
+        LineItem item2 = sampleLineItem();
+        TotalsInformation totals1 = sampleTotals();
+        TotalsInformation totals2 = sampleTotals();
+        LocalDateTime timestamp = LocalDateTime.of(2023, 5, 1, 12, 0);
+
+        CIIMessage message1 = CIIMessage.builder()
+                .messageId("MSG1")
+                .messageType(MessageType.INVOICE)
+                .creationDateTime(timestamp)
+                .senderPartyId("SENDER")
+                .receiverPartyId("RECEIVER")
+                .header(header1)
+                .lineItems(List.of(item1))
+                .totals(totals1)
+                .build();
+
+        CIIMessage message2 = CIIMessage.builder()
+                .messageId("MSG1")
+                .messageType(MessageType.INVOICE)
+                .creationDateTime(timestamp)
+                .senderPartyId("SENDER")
+                .receiverPartyId("RECEIVER")
+                .header(header2)
+                .lineItems(List.of(item2))
+                .totals(totals2)
+                .build();
+
+        CIIMessage message3 = CIIMessage.builder()
+                .messageId("MSG2")
+                .messageType(MessageType.ORDER)
+                .creationDateTime(timestamp.plusDays(1))
+                .senderPartyId("OTHER")
+                .receiverPartyId("RECEIVER")
+                .header(header1)
+                .lineItems(List.of(item1))
+                .totals(totals1)
+                .build();
+
+        assertEquals(message1, message2);
+        assertEquals(message1.hashCode(), message2.hashCode());
+        assertNotEquals(message1, message3);
+    }
+}

--- a/cii-messaging-parent/cii-model/src/test/java/com/cii/messaging/model/DeliveryInformationTest.java
+++ b/cii-messaging-parent/cii-model/src/test/java/com/cii/messaging/model/DeliveryInformationTest.java
@@ -1,0 +1,71 @@
+package com.cii.messaging.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DeliveryInformationTest {
+
+    @Test
+    void builderShouldSetFields() {
+        Address address = Address.builder()
+                .street("123 Main St")
+                .city("Springfield")
+                .postalCode("12345")
+                .countryCode("US")
+                .countryName("United States")
+                .build();
+
+        LocalDate date = LocalDate.of(2023, 5, 20);
+
+        DeliveryInformation info = DeliveryInformation.builder()
+                .deliveryDate(date)
+                .deliveryLocationId("LOC1")
+                .deliveryAddress(address)
+                .deliveryPartyName("John Doe")
+                .build();
+
+        assertEquals(date, info.getDeliveryDate());
+        assertEquals("LOC1", info.getDeliveryLocationId());
+        assertEquals(address, info.getDeliveryAddress());
+        assertEquals("John Doe", info.getDeliveryPartyName());
+    }
+
+    @Test
+    void equalsAndHashCodeShouldWork() {
+        Address address = Address.builder()
+                .street("123 Main St")
+                .city("Springfield")
+                .postalCode("12345")
+                .countryCode("US")
+                .countryName("United States")
+                .build();
+
+        DeliveryInformation info1 = DeliveryInformation.builder()
+                .deliveryDate(LocalDate.of(2023, 5, 20))
+                .deliveryLocationId("LOC1")
+                .deliveryAddress(address)
+                .deliveryPartyName("John Doe")
+                .build();
+
+        DeliveryInformation info2 = DeliveryInformation.builder()
+                .deliveryDate(LocalDate.of(2023, 5, 20))
+                .deliveryLocationId("LOC1")
+                .deliveryAddress(address)
+                .deliveryPartyName("John Doe")
+                .build();
+
+        DeliveryInformation info3 = DeliveryInformation.builder()
+                .deliveryDate(LocalDate.of(2023, 5, 21))
+                .deliveryLocationId("LOC2")
+                .deliveryAddress(address)
+                .deliveryPartyName("Jane Doe")
+                .build();
+
+        assertEquals(info1, info2);
+        assertEquals(info1.hashCode(), info2.hashCode());
+        assertNotEquals(info1, info3);
+    }
+}

--- a/cii-messaging-parent/cii-model/src/test/java/com/cii/messaging/model/DocumentHeaderTest.java
+++ b/cii-messaging-parent/cii-model/src/test/java/com/cii/messaging/model/DocumentHeaderTest.java
@@ -1,0 +1,107 @@
+package com.cii.messaging.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DocumentHeaderTest {
+
+    private PaymentTerms samplePaymentTerms() {
+        return PaymentTerms.builder()
+                .description("Net 30")
+                .dueDate(LocalDate.of(2023, 6, 15))
+                .paymentMeansCode("30")
+                .accountNumber("123456")
+                .accountName("Main Account")
+                .financialInstitution("Bank")
+                .build();
+    }
+
+    private DeliveryInformation sampleDeliveryInfo() {
+        Address address = Address.builder()
+                .street("123 Main St")
+                .city("Springfield")
+                .postalCode("12345")
+                .countryCode("US")
+                .countryName("United States")
+                .build();
+
+        return DeliveryInformation.builder()
+                .deliveryDate(LocalDate.of(2023, 5, 20))
+                .deliveryLocationId("LOC1")
+                .deliveryAddress(address)
+                .deliveryPartyName("John Doe")
+                .build();
+    }
+
+    @Test
+    void builderShouldSetFields() {
+        PaymentTerms terms = samplePaymentTerms();
+        DeliveryInformation delivery = sampleDeliveryInfo();
+
+        DocumentHeader header = DocumentHeader.builder()
+                .documentNumber("INV-1")
+                .documentDate(LocalDate.of(2023, 5, 1))
+                .buyerReference("BUYER")
+                .sellerReference("SELLER")
+                .contractReference("CONTRACT")
+                .currency("USD")
+                .paymentTerms(terms)
+                .delivery(delivery)
+                .build();
+
+        assertEquals("INV-1", header.getDocumentNumber());
+        assertEquals(LocalDate.of(2023, 5, 1), header.getDocumentDate());
+        assertEquals("BUYER", header.getBuyerReference());
+        assertEquals("SELLER", header.getSellerReference());
+        assertEquals("CONTRACT", header.getContractReference());
+        assertEquals("USD", header.getCurrency());
+        assertEquals(terms, header.getPaymentTerms());
+        assertEquals(delivery, header.getDelivery());
+    }
+
+    @Test
+    void equalsAndHashCodeShouldWork() {
+        PaymentTerms terms = samplePaymentTerms();
+        DeliveryInformation delivery = sampleDeliveryInfo();
+
+        DocumentHeader header1 = DocumentHeader.builder()
+                .documentNumber("INV-1")
+                .documentDate(LocalDate.of(2023, 5, 1))
+                .buyerReference("BUYER")
+                .sellerReference("SELLER")
+                .contractReference("CONTRACT")
+                .currency("USD")
+                .paymentTerms(terms)
+                .delivery(delivery)
+                .build();
+
+        DocumentHeader header2 = DocumentHeader.builder()
+                .documentNumber("INV-1")
+                .documentDate(LocalDate.of(2023, 5, 1))
+                .buyerReference("BUYER")
+                .sellerReference("SELLER")
+                .contractReference("CONTRACT")
+                .currency("USD")
+                .paymentTerms(terms)
+                .delivery(delivery)
+                .build();
+
+        DocumentHeader header3 = DocumentHeader.builder()
+                .documentNumber("INV-2")
+                .documentDate(LocalDate.of(2023, 6, 1))
+                .buyerReference("OTHER")
+                .sellerReference("SELLER")
+                .contractReference("CONTRACT")
+                .currency("EUR")
+                .paymentTerms(terms)
+                .delivery(delivery)
+                .build();
+
+        assertEquals(header1, header2);
+        assertEquals(header1.hashCode(), header2.hashCode());
+        assertNotEquals(header1, header3);
+    }
+}

--- a/cii-messaging-parent/cii-model/src/test/java/com/cii/messaging/model/LineItemTest.java
+++ b/cii-messaging-parent/cii-model/src/test/java/com/cii/messaging/model/LineItemTest.java
@@ -1,0 +1,78 @@
+package com.cii.messaging.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LineItemTest {
+
+    @Test
+    void builderShouldSetFields() {
+        LineItem item = LineItem.builder()
+                .lineNumber("1")
+                .productId("P001")
+                .description("Product 1")
+                .quantity(new BigDecimal("2"))
+                .unitCode("EA")
+                .unitPrice(new BigDecimal("10"))
+                .lineAmount(new BigDecimal("20"))
+                .taxRate(new BigDecimal("0.2"))
+                .taxCategory("VAT")
+                .build();
+
+        assertEquals("1", item.getLineNumber());
+        assertEquals("P001", item.getProductId());
+        assertEquals("Product 1", item.getDescription());
+        assertEquals(new BigDecimal("2"), item.getQuantity());
+        assertEquals("EA", item.getUnitCode());
+        assertEquals(new BigDecimal("10"), item.getUnitPrice());
+        assertEquals(new BigDecimal("20"), item.getLineAmount());
+        assertEquals(new BigDecimal("0.2"), item.getTaxRate());
+        assertEquals("VAT", item.getTaxCategory());
+    }
+
+    @Test
+    void equalsAndHashCodeShouldWork() {
+        LineItem item1 = LineItem.builder()
+                .lineNumber("1")
+                .productId("P001")
+                .description("Product 1")
+                .quantity(new BigDecimal("2"))
+                .unitCode("EA")
+                .unitPrice(new BigDecimal("10"))
+                .lineAmount(new BigDecimal("20"))
+                .taxRate(new BigDecimal("0.2"))
+                .taxCategory("VAT")
+                .build();
+
+        LineItem item2 = LineItem.builder()
+                .lineNumber("1")
+                .productId("P001")
+                .description("Product 1")
+                .quantity(new BigDecimal("2"))
+                .unitCode("EA")
+                .unitPrice(new BigDecimal("10"))
+                .lineAmount(new BigDecimal("20"))
+                .taxRate(new BigDecimal("0.2"))
+                .taxCategory("VAT")
+                .build();
+
+        LineItem item3 = LineItem.builder()
+                .lineNumber("2")
+                .productId("P002")
+                .description("Product 2")
+                .quantity(new BigDecimal("1"))
+                .unitCode("EA")
+                .unitPrice(new BigDecimal("15"))
+                .lineAmount(new BigDecimal("15"))
+                .taxRate(new BigDecimal("0.1"))
+                .taxCategory("VAT")
+                .build();
+
+        assertEquals(item1, item2);
+        assertEquals(item1.hashCode(), item2.hashCode());
+        assertNotEquals(item1, item3);
+    }
+}

--- a/cii-messaging-parent/cii-model/src/test/java/com/cii/messaging/model/PaymentTermsTest.java
+++ b/cii-messaging-parent/cii-model/src/test/java/com/cii/messaging/model/PaymentTermsTest.java
@@ -1,0 +1,64 @@
+package com.cii.messaging.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PaymentTermsTest {
+
+    @Test
+    void builderShouldSetFields() {
+        LocalDate due = LocalDate.of(2023, 6, 15);
+        PaymentTerms terms = PaymentTerms.builder()
+                .description("Net 30")
+                .dueDate(due)
+                .paymentMeansCode("30")
+                .accountNumber("123456")
+                .accountName("Main Account")
+                .financialInstitution("Bank")
+                .build();
+
+        assertEquals("Net 30", terms.getDescription());
+        assertEquals(due, terms.getDueDate());
+        assertEquals("30", terms.getPaymentMeansCode());
+        assertEquals("123456", terms.getAccountNumber());
+        assertEquals("Main Account", terms.getAccountName());
+        assertEquals("Bank", terms.getFinancialInstitution());
+    }
+
+    @Test
+    void equalsAndHashCodeShouldWork() {
+        PaymentTerms terms1 = PaymentTerms.builder()
+                .description("Net 30")
+                .dueDate(LocalDate.of(2023, 6, 15))
+                .paymentMeansCode("30")
+                .accountNumber("123456")
+                .accountName("Main Account")
+                .financialInstitution("Bank")
+                .build();
+
+        PaymentTerms terms2 = PaymentTerms.builder()
+                .description("Net 30")
+                .dueDate(LocalDate.of(2023, 6, 15))
+                .paymentMeansCode("30")
+                .accountNumber("123456")
+                .accountName("Main Account")
+                .financialInstitution("Bank")
+                .build();
+
+        PaymentTerms terms3 = PaymentTerms.builder()
+                .description("Net 60")
+                .dueDate(LocalDate.of(2023, 7, 15))
+                .paymentMeansCode("60")
+                .accountNumber("654321")
+                .accountName("Other Account")
+                .financialInstitution("Other Bank")
+                .build();
+
+        assertEquals(terms1, terms2);
+        assertEquals(terms1.hashCode(), terms2.hashCode());
+        assertNotEquals(terms1, terms3);
+    }
+}

--- a/cii-messaging-parent/cii-model/src/test/java/com/cii/messaging/model/TotalsInformationTest.java
+++ b/cii-messaging-parent/cii-model/src/test/java/com/cii/messaging/model/TotalsInformationTest.java
@@ -1,0 +1,63 @@
+package com.cii.messaging.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TotalsInformationTest {
+
+    @Test
+    void builderShouldSetFields() {
+        TotalsInformation totals = TotalsInformation.builder()
+                .lineTotalAmount(new BigDecimal("100"))
+                .taxBasisAmount(new BigDecimal("100"))
+                .taxTotalAmount(new BigDecimal("20"))
+                .grandTotalAmount(new BigDecimal("120"))
+                .prepaidAmount(new BigDecimal("0"))
+                .duePayableAmount(new BigDecimal("120"))
+                .build();
+
+        assertEquals(new BigDecimal("100"), totals.getLineTotalAmount());
+        assertEquals(new BigDecimal("100"), totals.getTaxBasisAmount());
+        assertEquals(new BigDecimal("20"), totals.getTaxTotalAmount());
+        assertEquals(new BigDecimal("120"), totals.getGrandTotalAmount());
+        assertEquals(new BigDecimal("0"), totals.getPrepaidAmount());
+        assertEquals(new BigDecimal("120"), totals.getDuePayableAmount());
+    }
+
+    @Test
+    void equalsAndHashCodeShouldWork() {
+        TotalsInformation totals1 = TotalsInformation.builder()
+                .lineTotalAmount(new BigDecimal("100"))
+                .taxBasisAmount(new BigDecimal("100"))
+                .taxTotalAmount(new BigDecimal("20"))
+                .grandTotalAmount(new BigDecimal("120"))
+                .prepaidAmount(new BigDecimal("0"))
+                .duePayableAmount(new BigDecimal("120"))
+                .build();
+
+        TotalsInformation totals2 = TotalsInformation.builder()
+                .lineTotalAmount(new BigDecimal("100"))
+                .taxBasisAmount(new BigDecimal("100"))
+                .taxTotalAmount(new BigDecimal("20"))
+                .grandTotalAmount(new BigDecimal("120"))
+                .prepaidAmount(new BigDecimal("0"))
+                .duePayableAmount(new BigDecimal("120"))
+                .build();
+
+        TotalsInformation totals3 = TotalsInformation.builder()
+                .lineTotalAmount(new BigDecimal("200"))
+                .taxBasisAmount(new BigDecimal("200"))
+                .taxTotalAmount(new BigDecimal("40"))
+                .grandTotalAmount(new BigDecimal("240"))
+                .prepaidAmount(new BigDecimal("10"))
+                .duePayableAmount(new BigDecimal("230"))
+                .build();
+
+        assertEquals(totals1, totals2);
+        assertEquals(totals1.hashCode(), totals2.hashCode());
+        assertNotEquals(totals1, totals3);
+    }
+}


### PR DESCRIPTION
## Summary
- add JUnit 5 tests verifying builder and Lombok-generated equals/hashCode for Address, DeliveryInformation, PaymentTerms, DocumentHeader, LineItem, TotalsInformation and CIIMessage models

## Testing
- `mvn -q test` *(fails: Plugin org.codehaus.mojo:jaxb2-maven-plugin:3.3.0 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6891e31bae4c832e920233f5a2451519