### PR TITLE
Add messaging service components

### DIFF
--- a/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/OrderReader.java
+++ b/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/OrderReader.java
@@ -1,0 +1,31 @@
+package com.cii.messaging.reader;
+
+import com.cii.messaging.model.CIIMessage;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
+import java.io.StringReader;
+
+/**
+ * Utility for converting XML order documents into {@link CIIMessage} instances.
+ */
+public class OrderReader {
+
+    private final JAXBContext context;
+
+    public OrderReader() throws JAXBException {
+        this.context = JAXBContext.newInstance(CIIMessage.class);
+    }
+
+    /**
+     * Parses the provided XML into a {@link CIIMessage}.
+     *
+     * @param xml XML string representing the CII message
+     * @return parsed {@link CIIMessage}
+     * @throws JAXBException if parsing fails
+     */
+    public CIIMessage read(String xml) throws JAXBException {
+        Unmarshaller unmarshaller = context.createUnmarshaller();
+        return (CIIMessage) unmarshaller.unmarshal(new StringReader(xml));
+    }
+}

--- a/cii-messaging-parent/cii-service/src/main/java/com/cii/messaging/service/MessageService.java
+++ b/cii-messaging-parent/cii-service/src/main/java/com/cii/messaging/service/MessageService.java
@@ -1,0 +1,59 @@
+package com.cii.messaging.service;
+
+import com.cii.messaging.model.CIIMessage;
+import com.cii.messaging.reader.OrderReader;
+import com.cii.messaging.validator.MessageValidator;
+import com.cii.messaging.writer.InvoiceWriter;
+
+/**
+ * Facade for generating, parsing and validating CII messages.
+ */
+public class MessageService {
+
+    private final OrderReader reader;
+    private final InvoiceWriter writer;
+    private final MessageValidator validator;
+
+    public MessageService(OrderReader reader, InvoiceWriter writer, MessageValidator validator) {
+        this.reader = reader;
+        this.writer = writer;
+        this.validator = validator;
+    }
+
+    /**
+     * Generates an XML representation of the supplied message.
+     *
+     * @param message message to serialize
+     * @return XML string
+     * @throws Exception if serialization or validation fails
+     */
+    public String generate(CIIMessage message) throws Exception {
+        validator.validate(message);
+        return writer.write(message);
+    }
+
+    /**
+     * Parses the provided XML into a {@link CIIMessage}.
+     *
+     * @param xml message in XML form
+     * @return parsed message
+     * @throws Exception if parsing or validation fails
+     */
+    public CIIMessage parse(String xml) throws Exception {
+        CIIMessage message = reader.read(xml);
+        validator.validate(message);
+        return message;
+    }
+
+    /**
+     * Validates the supplied message.
+     *
+     * @param message message to validate
+     * @return {@code true} if validation succeeds
+     * @throws Exception if validation fails
+     */
+    public boolean validate(CIIMessage message) throws Exception {
+        validator.validate(message);
+        return true;
+    }
+}

--- a/cii-messaging-parent/cii-validator/pom.xml
+++ b/cii-messaging-parent/cii-validator/pom.xml
@@ -32,6 +32,11 @@
             <artifactId>Saxon-HE</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.helger</groupId>
+            <artifactId>ph-schematron</artifactId>
+            <version>${phax.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.helger.cii</groupId>
             <artifactId>ph-cii-d16b</artifactId>
         </dependency>

--- a/cii-messaging-parent/cii-validator/src/main/java/com/cii/messaging/validator/MessageValidator.java
+++ b/cii-messaging-parent/cii-validator/src/main/java/com/cii/messaging/validator/MessageValidator.java
@@ -1,0 +1,66 @@
+package com.cii.messaging.validator;
+
+import com.cii.messaging.model.CIIMessage;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.Marshaller;
+import net.sf.saxon.s9api.Processor;
+import net.sf.saxon.s9api.Serializer;
+import net.sf.saxon.s9api.XsltCompiler;
+import net.sf.saxon.s9api.XsltExecutable;
+import net.sf.saxon.s9api.XsltTransformer;
+
+import javax.xml.XMLConstants;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.validation.Validator;
+import java.io.File;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.Writer;
+
+/**
+ * Performs XSD and Schematron validation on CII messages.
+ */
+public class MessageValidator {
+
+    private final Schema schema;
+    private final XsltExecutable schematronXslt;
+
+    public MessageValidator(File xsdFile, File schematronXsltFile) throws Exception {
+        SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        this.schema = schemaFactory.newSchema(xsdFile);
+
+        Processor processor = new Processor(false);
+        XsltCompiler compiler = processor.newXsltCompiler();
+        this.schematronXslt = compiler.compile(new StreamSource(schematronXsltFile));
+    }
+
+    public void validate(String xml) throws Exception {
+        Validator validator = schema.newValidator();
+        validator.validate(new StreamSource(new StringReader(xml)));
+
+        Processor processor = new Processor(false);
+        XsltTransformer transformer = schematronXslt.load();
+        transformer.setSource(new StreamSource(new StringReader(xml)));
+        transformer.setDestination(new Serializer(new NullWriter()));
+        transformer.transform();
+    }
+
+    public void validate(CIIMessage message) throws Exception {
+        JAXBContext context = JAXBContext.newInstance(CIIMessage.class);
+        Marshaller marshaller = context.createMarshaller();
+        StringWriter writer = new StringWriter();
+        marshaller.marshal(message, writer);
+        validate(writer.toString());
+    }
+
+    private static class NullWriter extends Writer {
+        @Override
+        public void write(char[] cbuf, int off, int len) { }
+        @Override
+        public void flush() { }
+        @Override
+        public void close() { }
+    }
+}

--- a/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/InvoiceWriter.java
+++ b/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/InvoiceWriter.java
@@ -1,0 +1,33 @@
+package com.cii.messaging.writer;
+
+import com.cii.messaging.model.CIIMessage;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import java.io.StringWriter;
+
+/**
+ * Serializes {@link CIIMessage} instances into XML invoices.
+ */
+public class InvoiceWriter {
+
+    private final JAXBContext context;
+
+    public InvoiceWriter() throws JAXBException {
+        this.context = JAXBContext.newInstance(CIIMessage.class);
+    }
+
+    /**
+     * Marshals the provided message into an XML document.
+     *
+     * @param message message to marshal
+     * @return XML representation of the message
+     * @throws JAXBException if marshalling fails
+     */
+    public String write(CIIMessage message) throws JAXBException {
+        Marshaller marshaller = context.createMarshaller();
+        StringWriter writer = new StringWriter();
+        marshaller.marshal(message, writer);
+        return writer.toString();
+    }
+}


### PR DESCRIPTION
## Summary
- add JAXB-based OrderReader to convert XML into CIIMessage
- add InvoiceWriter to marshal CIIMessage into XML
- introduce MessageValidator for XSD and Schematron validation with ph-schematron dependency
- create MessageService facade for generate/parse/validate workflows

## Testing
- `mvn -pl cii-service,cii-reader,cii-writer,cii-validator -am test` *(fails: org.codehaus.mojo:jaxb2-maven-plugin:pom:3.3.0; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6891e311f018832e91fd54fd90e6f4f0