### PR TITLE
Ensure UTF-8 encoding for file IO and add non-ASCII tests

### DIFF
--- a/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/ConvertCommand.java
+++ b/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/ConvertCommand.java
@@ -6,6 +6,7 @@ import com.cii.messaging.service.CIIMessagingService;
 import com.cii.messaging.service.impl.CIIMessagingServiceImpl;
 import picocli.CommandLine.*;
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.concurrent.Callable;
 
@@ -39,7 +40,7 @@ public class ConvertCommand implements Callable<Integer> {
         System.out.println("Converting " + inputFile.getName() + " to " + targetFormat + "...");
         
         try {
-            String inputContent = Files.readString(inputFile.toPath());
+            String inputContent = Files.readString(inputFile.toPath(), StandardCharsets.UTF_8);
             boolean isInputJson = inputContent.trim().startsWith("{");
             
             if ("JSON".equalsIgnoreCase(targetFormat)) {
@@ -50,7 +51,7 @@ public class ConvertCommand implements Callable<Integer> {
                 // XML to JSON
                 CIIMessage message = service.readMessage(inputFile);
                 String json = service.convertToJson(message);
-                Files.writeString(outputFile.toPath(), json);
+                Files.writeString(outputFile.toPath(), json, StandardCharsets.UTF_8);
                 
             } else if ("XML".equalsIgnoreCase(targetFormat)) {
                 if (!isInputJson) {

--- a/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/GenerateCommand.java
+++ b/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/GenerateCommand.java
@@ -70,7 +70,8 @@ public class GenerateCommand implements Callable<Integer> {
         // Write output
         if ("JSON".equalsIgnoreCase(format)) {
             String json = service.convertToJson(message);
-            java.nio.file.Files.write(outputFile.toPath(), json.getBytes());
+            java.nio.file.Files.writeString(outputFile.toPath(), json,
+                    java.nio.charset.StandardCharsets.UTF_8);
         } else {
             service.writeMessage(message, outputFile);
         }

--- a/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/ParseCommand.java
+++ b/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/ParseCommand.java
@@ -46,7 +46,8 @@ public class ParseCommand implements Callable<Integer> {
             }
             
             if (outputFile != null) {
-                java.nio.file.Files.write(outputFile.toPath(), output.getBytes());
+                java.nio.file.Files.writeString(outputFile.toPath(), output,
+                        java.nio.charset.StandardCharsets.UTF_8);
                 System.out.println("Output saved to: " + outputFile.getAbsolutePath());
             } else {
                 System.out.println("\n" + output);

--- a/cii-messaging-parent/cii-service/src/main/java/com/cii/messaging/service/impl/CIIMessagingServiceImpl.java
+++ b/cii-messaging-parent/cii-service/src/main/java/com/cii/messaging/service/impl/CIIMessagingServiceImpl.java
@@ -12,6 +12,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -220,7 +222,7 @@ public class CIIMessagingServiceImpl implements CIIMessagingService {
     // Helper methods
     
     private String readFileContent(File file) throws IOException {
-        try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+        try (BufferedReader reader = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {
             StringBuilder content = new StringBuilder();
             String line;
             while ((line = reader.readLine()) != null) {


### PR DESCRIPTION
## Summary
- Use UTF-8 when generating, parsing, and converting messages in CLI commands
- Read files with UTF-8 in `CIIMessagingServiceImpl`
- Add integration test verifying handling of non-ASCII characters

## Testing
- `mvn -q test` *(fails: org.codehaus.mojo:jaxb2-maven-plugin:pom:3.3.0: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6891ef622790832e93fa12e638828b11