### PR TITLE
Harden XML parsing against XXE

### DIFF
--- a/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/impl/DesadvReader.java
+++ b/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/impl/DesadvReader.java
@@ -24,6 +24,11 @@ public class DesadvReader extends AbstractCIIReader {
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
             factory.setNamespaceAware(true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setXIncludeAware(false);
+            factory.setExpandEntityReferences(false);
             DocumentBuilder builder = factory.newDocumentBuilder();
             Document doc = builder.parse(xmlFile);
             return parseDocument(doc);

--- a/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/impl/InvoiceReader.java
+++ b/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/impl/InvoiceReader.java
@@ -30,6 +30,11 @@ public class InvoiceReader extends AbstractCIIReader {
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
             factory.setNamespaceAware(true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setXIncludeAware(false);
+            factory.setExpandEntityReferences(false);
             DocumentBuilder builder = factory.newDocumentBuilder();
             Document doc = builder.parse(xmlFile);
             return parseInvoiceDocument(doc);
@@ -43,6 +48,11 @@ public class InvoiceReader extends AbstractCIIReader {
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
             factory.setNamespaceAware(true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setXIncludeAware(false);
+            factory.setExpandEntityReferences(false);
             DocumentBuilder builder = factory.newDocumentBuilder();
             Document doc = builder.parse(inputStream);
             return parseInvoiceDocument(doc);

--- a/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/impl/OrderReader.java
+++ b/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/impl/OrderReader.java
@@ -29,6 +29,11 @@ public class OrderReader extends AbstractCIIReader {
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
             factory.setNamespaceAware(true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setXIncludeAware(false);
+            factory.setExpandEntityReferences(false);
             DocumentBuilder builder = factory.newDocumentBuilder();
             Document doc = builder.parse(xmlFile);
             return parseOrderDocument(doc);
@@ -42,6 +47,11 @@ public class OrderReader extends AbstractCIIReader {
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
             factory.setNamespaceAware(true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setXIncludeAware(false);
+            factory.setExpandEntityReferences(false);
             DocumentBuilder builder = factory.newDocumentBuilder();
             Document doc = builder.parse(inputStream);
             return parseOrderDocument(doc);

--- a/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/impl/OrderResponseReader.java
+++ b/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/impl/OrderResponseReader.java
@@ -24,6 +24,11 @@ public class OrderResponseReader extends AbstractCIIReader {
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
             factory.setNamespaceAware(true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setXIncludeAware(false);
+            factory.setExpandEntityReferences(false);
             DocumentBuilder builder = factory.newDocumentBuilder();
             Document doc = builder.parse(xmlFile);
             return parseDocument(doc);

--- a/cii-messaging-parent/cii-reader/src/test/java/com/cii/messaging/reader/XXEReaderTest.java
+++ b/cii-messaging-parent/cii-reader/src/test/java/com/cii/messaging/reader/XXEReaderTest.java
@@ -1,0 +1,72 @@
+package com.cii.messaging.reader;
+
+import com.cii.messaging.reader.CIIReaderException;
+import com.cii.messaging.reader.impl.DesadvReader;
+import com.cii.messaging.reader.impl.InvoiceReader;
+import com.cii.messaging.reader.impl.OrderReader;
+import com.cii.messaging.reader.impl.OrderResponseReader;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.SAXParseException;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class XXEReaderTest {
+    private static final String XXE = """
+            <?xml version=\"1.0\"?>
+            <!DOCTYPE foo [<!ELEMENT foo ANY><!ENTITY xxe SYSTEM \"file:///etc/passwd\">]>
+            <foo>&xxe;</foo>
+            """;
+
+    private File createTempXml() throws IOException {
+        File temp = File.createTempFile("xxe", ".xml");
+        Files.writeString(temp.toPath(), XXE);
+        return temp;
+    }
+
+    @Test
+    void orderReaderRejectsExternalEntities() throws Exception {
+        OrderReader reader = new OrderReader();
+        File file = createTempXml();
+        CIIReaderException ex = assertThrows(CIIReaderException.class, () -> reader.read(file));
+        assertTrue(ex.getCause() instanceof SAXParseException);
+    }
+
+    @Test
+    void invoiceReaderRejectsExternalEntities() throws Exception {
+        InvoiceReader reader = new InvoiceReader();
+        File file = createTempXml();
+        CIIReaderException ex = assertThrows(CIIReaderException.class, () -> reader.read(file));
+        assertTrue(ex.getCause() instanceof SAXParseException);
+    }
+
+    @Test
+    void invoiceReaderRejectsExternalEntitiesFromStream() {
+        InvoiceReader reader = new InvoiceReader();
+        InputStream is = new ByteArrayInputStream(XXE.getBytes(StandardCharsets.UTF_8));
+        CIIReaderException ex = assertThrows(CIIReaderException.class, () -> reader.read(is));
+        assertTrue(ex.getCause() instanceof SAXParseException);
+    }
+
+    @Test
+    void desadvReaderRejectsExternalEntities() throws Exception {
+        DesadvReader reader = new DesadvReader();
+        File file = createTempXml();
+        CIIReaderException ex = assertThrows(CIIReaderException.class, () -> reader.read(file));
+        assertTrue(ex.getCause() instanceof SAXParseException);
+    }
+
+    @Test
+    void orderResponseReaderRejectsExternalEntities() throws Exception {
+        OrderResponseReader reader = new OrderResponseReader();
+        File file = createTempXml();
+        CIIReaderException ex = assertThrows(CIIReaderException.class, () -> reader.read(file));
+        assertTrue(ex.getCause() instanceof SAXParseException);
+    }
+}

--- a/cii-messaging-parent/cii-validator/src/main/java/com/cii/messaging/validator/impl/XSDValidator.java
+++ b/cii-messaging-parent/cii-validator/src/main/java/com/cii/messaging/validator/impl/XSDValidator.java
@@ -84,6 +84,11 @@ public class XSDValidator implements CIIValidator {
             // Simple well-formedness check
             javax.xml.parsers.DocumentBuilderFactory factory = javax.xml.parsers.DocumentBuilderFactory.newInstance();
             factory.setNamespaceAware(true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setXIncludeAware(false);
+            factory.setExpandEntityReferences(false);
             javax.xml.parsers.DocumentBuilder builder = factory.newDocumentBuilder();
             builder.parse(inputStream);
             

--- a/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/validator/XSDValidatorXXETest.java
+++ b/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/validator/XSDValidatorXXETest.java
@@ -1,0 +1,27 @@
+package com.cii.messaging.validator;
+
+import com.cii.messaging.validator.impl.XSDValidator;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class XSDValidatorXXETest {
+    private static final String XXE = """
+            <?xml version=\"1.0\"?>
+            <!DOCTYPE foo [<!ELEMENT foo ANY><!ENTITY xxe SYSTEM \"file:///etc/passwd\">]>
+            <foo>&xxe;</foo>
+            """;
+
+    @Test
+    void xsdValidatorRejectsExternalEntities() {
+        XSDValidator validator = new XSDValidator();
+        ByteArrayInputStream input = new ByteArrayInputStream(XXE.getBytes(StandardCharsets.UTF_8));
+        ValidationResult result = validator.validate(input);
+        assertFalse(result.isValid());
+        assertFalse(result.getErrors().isEmpty());
+        assertTrue(result.getErrors().get(0).getMessage().contains("DOCTYPE"));
+    }
+}


### PR DESCRIPTION
## Summary
- harden readers and validator against XXE by disabling DOCTYPE and external entity processing
- add regression tests confirming external entities are rejected

## Testing
- `mvn -q -pl cii-reader,cii-validator -am test` *(fails: Plugin org.codehaus.mojo:jaxb2-maven-plugin:pom:3.3.0 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6891ef597210832ea1e83b886ad9f82a