### PR TITLE
chore: remove unused ObjectMapper from ParseCommand

### DIFF
--- a/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/ParseCommand.java
+++ b/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/ParseCommand.java
@@ -3,7 +3,6 @@ package com.cii.messaging.cli;
 import com.cii.messaging.model.CIIMessage;
 import com.cii.messaging.service.CIIMessagingService;
 import com.cii.messaging.service.impl.CIIMessagingServiceImpl;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import picocli.CommandLine.*;
 import java.io.File;
 import java.util.concurrent.Callable;
@@ -24,7 +23,6 @@ public class ParseCommand implements Callable<Integer> {
     private String format;
     
     private final CIIMessagingService service = new CIIMessagingServiceImpl();
-    private final ObjectMapper mapper = new ObjectMapper();
     
     @Override
     public Integer call() throws Exception {


### PR DESCRIPTION
## Summary
- remove unused `ObjectMapper` field from `ParseCommand`

## Testing
- `javac -cp /tmp/stubs -d /tmp/out -Xlint:all src/main/java/com/cii/messaging/cli/ParseCommand.java /tmp/stubs/com/cii/messaging/service/CIIMessagingService.java /tmp/stubs/com/cii/messaging/service/impl/CIIMessagingServiceImpl.java /tmp/stubs/com/cii/messaging/model/CIIMessage.java /tmp/stubs/com/cii/messaging/model/DocumentHeader.java /tmp/stubs/com/cii/messaging/model/LineItem.java /tmp/stubs/com/cii/messaging/model/TotalsInformation.java /tmp/stubs/picocli/CommandLine.java`

------
https://chatgpt.com/codex/tasks/task_e_6891ef564384832eb63a24e4e38d26a7