### PR TITLE
Implement composite validator streaming and message support

### DIFF
--- a/cii-messaging-parent/cii-validator/pom.xml
+++ b/cii-messaging-parent/cii-validator/pom.xml
@@ -24,6 +24,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.cii.messaging</groupId>
+            <artifactId>cii-writer</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
         </dependency>

--- a/cii-messaging-parent/cii-validator/src/main/java/com/cii/messaging/validator/impl/CompositeValidator.java
+++ b/cii-messaging-parent/cii-validator/src/main/java/com/cii/messaging/validator/impl/CompositeValidator.java
@@ -2,9 +2,15 @@ package com.cii.messaging.validator.impl;
 
 import com.cii.messaging.model.CIIMessage;
 import com.cii.messaging.validator.*;
+import com.cii.messaging.writer.CIIWriter;
+import com.cii.messaging.writer.CIIWriterException;
+import com.cii.messaging.writer.CIIWriterFactory;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -56,24 +62,83 @@ public class CompositeValidator implements CIIValidator {
     
     @Override
     public ValidationResult validate(InputStream inputStream) {
-        // Similar implementation to validate(File)
-        throw new UnsupportedOperationException("Stream validation not implemented for composite validator");
+        try {
+            byte[] data = inputStream.readAllBytes();
+            return validateBuffered(data);
+        } catch (IOException e) {
+            ValidationError error = ValidationError.builder()
+                    .message("Failed to read input stream: " + e.getMessage())
+                    .severity(ValidationError.ErrorSeverity.FATAL)
+                    .build();
+            List<ValidationError> errors = new ArrayList<>();
+            errors.add(error);
+            return ValidationResult.builder()
+                    .valid(false)
+                    .errors(errors)
+                    .build();
+        }
     }
-    
+
     @Override
     public ValidationResult validate(String xmlContent) {
-        // Similar implementation
-        throw new UnsupportedOperationException("String validation not implemented for composite validator");
+        byte[] data = xmlContent.getBytes(StandardCharsets.UTF_8);
+        return validateBuffered(data);
     }
-    
+
     @Override
     public ValidationResult validate(CIIMessage message) {
-        throw new UnsupportedOperationException("Message validation not implemented for composite validator");
+        try {
+            CIIWriter writer = CIIWriterFactory.createWriter(message.getMessageType());
+            String xml = writer.writeToString(message);
+            return validate(xml);
+        } catch (CIIWriterException e) {
+            ValidationError error = ValidationError.builder()
+                    .message("Failed to serialize message: " + e.getMessage())
+                    .severity(ValidationError.ErrorSeverity.FATAL)
+                    .build();
+            List<ValidationError> errors = new ArrayList<>();
+            errors.add(error);
+            return ValidationResult.builder()
+                    .valid(false)
+                    .errors(errors)
+                    .build();
+        }
     }
     
     @Override
     public void setSchemaVersion(SchemaVersion version) {
         this.schemaVersion = version;
         validators.forEach(v -> v.setSchemaVersion(version));
+    }
+
+    private ValidationResult validateBuffered(byte[] data) {
+        ValidationResult.ValidationResultBuilder combinedResult = ValidationResult.builder();
+        combinedResult.valid(true);
+
+        List<ValidationError> allErrors = new ArrayList<>();
+        List<ValidationWarning> allWarnings = new ArrayList<>();
+        StringBuilder validatedAgainst = new StringBuilder();
+
+        for (CIIValidator validator : validators) {
+            ValidationResult result = validator.validate(new ByteArrayInputStream(data));
+
+            if (!result.isValid()) {
+                combinedResult.valid(false);
+            }
+
+            allErrors.addAll(result.getErrors());
+            allWarnings.addAll(result.getWarnings());
+
+            if (validatedAgainst.length() > 0) {
+                validatedAgainst.append(", ");
+            }
+            validatedAgainst.append(result.getValidatedAgainst());
+        }
+
+        combinedResult.errors(allErrors);
+        combinedResult.warnings(allWarnings);
+        combinedResult.validatedAgainst(validatedAgainst.toString());
+
+        return combinedResult.build();
     }
 }

--- a/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/validator/impl/CompositeValidatorTest.java
+++ b/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/validator/impl/CompositeValidatorTest.java
@@ -1,0 +1,141 @@
+package com.cii.messaging.validator.impl;
+
+import com.cii.messaging.model.CIIMessage;
+import com.cii.messaging.model.MessageType;
+import com.cii.messaging.validator.*;
+import org.junit.jupiter.api.Test;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CompositeValidatorTest {
+
+    private static class RecordingValidator implements CIIValidator {
+        private final ValidationResult result;
+        private String lastInput;
+
+        RecordingValidator(ValidationResult result) {
+            this.result = result;
+        }
+
+        @Override
+        public ValidationResult validate(File xmlFile) {
+            try (InputStream is = new FileInputStream(xmlFile)) {
+                return validate(is);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public ValidationResult validate(InputStream inputStream) {
+            try {
+                lastInput = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            return result;
+        }
+
+        @Override
+        public ValidationResult validate(String xmlContent) {
+            lastInput = xmlContent;
+            return result;
+        }
+
+        @Override
+        public ValidationResult validate(CIIMessage message) {
+            lastInput = "message";
+            return result;
+        }
+
+        @Override
+        public void setSchemaVersion(SchemaVersion version) {
+        }
+    }
+
+    @Test
+    void allOverloadsAggregateChildResultsConsistently() throws Exception {
+        ValidationWarning warning = ValidationWarning.builder().message("warn").build();
+        ValidationError error = ValidationError.builder()
+                .message("err")
+                .severity(ValidationError.ErrorSeverity.ERROR)
+                .build();
+
+        ValidationResult res1 = ValidationResult.builder()
+                .valid(true)
+                .warnings(List.of(warning))
+                .validatedAgainst("V1")
+                .build();
+
+        ValidationResult res2 = ValidationResult.builder()
+                .valid(false)
+                .errors(List.of(error))
+                .validatedAgainst("V2")
+                .build();
+
+        RecordingValidator v1 = new RecordingValidator(res1);
+        RecordingValidator v2 = new RecordingValidator(res2);
+
+        CompositeValidator composite = new CompositeValidator();
+
+        // Remove default validators
+        java.lang.reflect.Field field = CompositeValidator.class.getDeclaredField("validators");
+        field.setAccessible(true);
+        List<CIIValidator> list = (List<CIIValidator>) field.get(composite);
+        list.clear();
+
+        composite.addValidator(v1);
+        composite.addValidator(v2);
+
+        String xml = "<test/>";
+
+        ValidationResult expected = ValidationResult.builder()
+                .valid(false)
+                .errors(List.of(error))
+                .warnings(List.of(warning))
+                .validatedAgainst("V1, V2")
+                .build();
+
+        // File
+        File temp = Files.createTempFile("cii", ".xml").toFile();
+        Files.writeString(temp.toPath(), xml, StandardCharsets.UTF_8);
+        ValidationResult fileResult = composite.validate(temp);
+        assertEquals(expected, fileResult);
+        assertEquals(xml, v1.lastInput);
+        assertEquals(xml, v2.lastInput);
+
+        // InputStream
+        ValidationResult streamResult = composite.validate(
+                new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+        assertEquals(expected, streamResult);
+        assertEquals(xml, v1.lastInput);
+        assertEquals(xml, v2.lastInput);
+
+        // String
+        ValidationResult stringResult = composite.validate(xml);
+        assertEquals(expected, stringResult);
+        assertEquals(xml, v1.lastInput);
+        assertEquals(xml, v2.lastInput);
+
+        // CIIMessage
+        CIIMessage msg = CIIMessage.builder()
+                .messageId("1")
+                .messageType(MessageType.INVOICE)
+                .creationDateTime(LocalDateTime.now())
+                .senderPartyId("S")
+                .receiverPartyId("R")
+                .build();
+
+        ValidationResult msgResult = composite.validate(msg);
+        assertEquals(expected, msgResult);
+        assertEquals(v1.lastInput, v2.lastInput);
+        assertNotNull(v1.lastInput);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Buffer input once for stream and string validation and reuse across validators
- Serialize `CIIMessage` to XML using writer and delegate to string validator
- Add unit tests ensuring all validation overloads aggregate child results consistently

## Testing
- `mvn -q -pl cii-validator test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6891ef515f4c832e98f8c9045b224fed