### PR TITLE
refactor: extract secure DocumentBuilder creation

### DIFF
--- a/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/impl/OrderReader.java
+++ b/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/impl/OrderReader.java
@@ -27,14 +27,7 @@ public class OrderReader extends AbstractCIIReader {
     @Override
     public CIIMessage read(File xmlFile) throws CIIReaderException {
         try {
-            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-            factory.setNamespaceAware(true);
-            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-            factory.setXIncludeAware(false);
-            factory.setExpandEntityReferences(false);
-            DocumentBuilder builder = factory.newDocumentBuilder();
+            DocumentBuilder builder = createSecureDocumentBuilder();
             Document doc = builder.parse(xmlFile);
             return parseOrderDocument(doc);
         } catch (Exception e) {
@@ -45,19 +38,23 @@ public class OrderReader extends AbstractCIIReader {
     @Override
     public CIIMessage read(InputStream inputStream) throws CIIReaderException {
         try {
-            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-            factory.setNamespaceAware(true);
-            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-            factory.setXIncludeAware(false);
-            factory.setExpandEntityReferences(false);
-            DocumentBuilder builder = factory.newDocumentBuilder();
+            DocumentBuilder builder = createSecureDocumentBuilder();
             Document doc = builder.parse(inputStream);
             return parseOrderDocument(doc);
         } catch (Exception e) {
             throw new CIIReaderException("Failed to read order from stream", e);
         }
+    }
+
+    private DocumentBuilder createSecureDocumentBuilder() throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
+        return factory.newDocumentBuilder();
     }
     
     @Override


### PR DESCRIPTION
## Summary
- factor out duplicated DocumentBuilderFactory setup into createSecureDocumentBuilder
- reuse secure builder in read(File) and read(InputStream)

## Testing
- `mvn -q -pl cii-reader -am test` *(fails: Plugin org.codehaus.mojo:jaxb2-maven-plugin:3.3.0 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6891f4504878832ea138362a6604e774