### PR TITLE
Add Schematron validation

### DIFF
--- a/cii-messaging-parent/cii-validator/src/main/resources/schematron/D16B.xslt
+++ b/cii-messaging-parent/cii-validator/src/main/resources/schematron/D16B.xslt
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="2.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
+    xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+    xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100">
+  <xsl:output method="xml" indent="yes"/>
+  <xsl:template match="/">
+    <svrl:schematron-output>
+      <xsl:apply-templates select="rsm:CrossIndustryInvoice"/>
+    </svrl:schematron-output>
+  </xsl:template>
+  <xsl:template match="rsm:CrossIndustryInvoice">
+    <!-- Warning if invoice ID missing -->
+    <xsl:if test="not(rsm:ExchangedDocument/ram:ID)">
+      <svrl:successful-report test="rsm:ExchangedDocument/ram:ID" location="/rsm:CrossIndustryInvoice">
+        <svrl:text>Invoice ID is missing</svrl:text>
+      </svrl:successful-report>
+    </xsl:if>
+    <!-- Error if no line items -->
+    <xsl:if test="not(rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem)">
+      <svrl:failed-assert test="rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem" location="/rsm:CrossIndustryInvoice">
+        <svrl:text>At least one line item required</svrl:text>
+      </svrl:failed-assert>
+    </xsl:if>
+  </xsl:template>
+</xsl:stylesheet>

--- a/cii-messaging-parent/cii-validator/src/main/resources/schematron/D20B.xslt
+++ b/cii-messaging-parent/cii-validator/src/main/resources/schematron/D20B.xslt
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="2.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
+    xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+    xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100">
+  <xsl:output method="xml" indent="yes"/>
+  <xsl:template match="/">
+    <svrl:schematron-output>
+      <xsl:apply-templates select="rsm:CrossIndustryInvoice"/>
+    </svrl:schematron-output>
+  </xsl:template>
+  <xsl:template match="rsm:CrossIndustryInvoice">
+    <!-- Warning if invoice ID missing -->
+    <xsl:if test="not(rsm:ExchangedDocument/ram:ID)">
+      <svrl:successful-report test="rsm:ExchangedDocument/ram:ID" location="/rsm:CrossIndustryInvoice">
+        <svrl:text>Invoice ID is missing</svrl:text>
+      </svrl:successful-report>
+    </xsl:if>
+    <!-- Error if no line items -->
+    <xsl:if test="not(rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem)">
+      <svrl:failed-assert test="rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem" location="/rsm:CrossIndustryInvoice">
+        <svrl:text>At least one line item required</svrl:text>
+      </svrl:failed-assert>
+    </xsl:if>
+  </xsl:template>
+</xsl:stylesheet>

--- a/cii-messaging-parent/cii-validator/src/main/resources/schematron/D21B.xslt
+++ b/cii-messaging-parent/cii-validator/src/main/resources/schematron/D21B.xslt
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="2.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
+    xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+    xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100">
+  <xsl:output method="xml" indent="yes"/>
+  <xsl:template match="/">
+    <svrl:schematron-output>
+      <xsl:apply-templates select="rsm:CrossIndustryInvoice"/>
+    </svrl:schematron-output>
+  </xsl:template>
+  <xsl:template match="rsm:CrossIndustryInvoice">
+    <!-- Warning if invoice ID missing -->
+    <xsl:if test="not(rsm:ExchangedDocument/ram:ID)">
+      <svrl:successful-report test="rsm:ExchangedDocument/ram:ID" location="/rsm:CrossIndustryInvoice">
+        <svrl:text>Invoice ID is missing</svrl:text>
+      </svrl:successful-report>
+    </xsl:if>
+    <!-- Error if no line items -->
+    <xsl:if test="not(rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem)">
+      <svrl:failed-assert test="rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem" location="/rsm:CrossIndustryInvoice">
+        <svrl:text>At least one line item required</svrl:text>
+      </svrl:failed-assert>
+    </xsl:if>
+  </xsl:template>
+</xsl:stylesheet>

--- a/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/validator/impl/SchematronValidatorTest.java
+++ b/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/validator/impl/SchematronValidatorTest.java
@@ -1,0 +1,39 @@
+package com.cii.messaging.validator.impl;
+
+import com.cii.messaging.validator.ValidationResult;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SchematronValidatorTest {
+
+    private final SchematronValidator validator = new SchematronValidator();
+
+    @Test
+    void validDocumentHasNoErrors() throws Exception {
+        String xml = Files.readString(Path.of("src", "test", "resources", "invoice-sample.xml"));
+        ValidationResult result = validator.validate(xml);
+        assertTrue(result.isValid());
+        assertTrue(result.getErrors().isEmpty());
+        assertTrue(result.getWarnings().isEmpty());
+    }
+
+    @Test
+    void missingIdAndLineItemProducesWarningAndError() {
+        String xml = """
+                <rsm:CrossIndustryInvoice xmlns:rsm=\"urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100\"
+                    xmlns:ram=\"urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100\">
+                    <rsm:ExchangedDocument/>
+                    <rsm:SupplyChainTradeTransaction/>
+                </rsm:CrossIndustryInvoice>
+                """;
+        ValidationResult result = validator.validate(xml);
+        assertFalse(result.isValid());
+        assertEquals(1, result.getErrors().size());
+        assertEquals(1, result.getWarnings().size());
+    }
+}
+


### PR DESCRIPTION
## Summary
- add simple Schematron rules under resources
- compile and execute Schematron XSLT in `SchematronValidator`
- validate SVRL output and surface warnings and errors

## Testing
- `mvn -q -pl cii-validator test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6891f45fcc88832e9f6a8efe797ed354