### PR TITLE
refactor: reuse secure builder in invoice reader

### DIFF
--- a/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/impl/InvoiceReader.java
+++ b/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/impl/InvoiceReader.java
@@ -28,14 +28,7 @@ public class InvoiceReader extends AbstractCIIReader {
     @Override
     public CIIMessage read(File xmlFile) throws CIIReaderException {
         try {
-            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-            factory.setNamespaceAware(true);
-            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-            factory.setXIncludeAware(false);
-            factory.setExpandEntityReferences(false);
-            DocumentBuilder builder = factory.newDocumentBuilder();
+            DocumentBuilder builder = createSecureDocumentBuilder();
             Document doc = builder.parse(xmlFile);
             return parseInvoiceDocument(doc);
         } catch (Exception e) {
@@ -46,21 +39,25 @@ public class InvoiceReader extends AbstractCIIReader {
     @Override
     public CIIMessage read(InputStream inputStream) throws CIIReaderException {
         try {
-            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-            factory.setNamespaceAware(true);
-            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-            factory.setXIncludeAware(false);
-            factory.setExpandEntityReferences(false);
-            DocumentBuilder builder = factory.newDocumentBuilder();
+            DocumentBuilder builder = createSecureDocumentBuilder();
             Document doc = builder.parse(inputStream);
             return parseInvoiceDocument(doc);
         } catch (Exception e) {
             throw new CIIReaderException("Failed to read invoice from stream", e);
         }
     }
-    
+
+    private DocumentBuilder createSecureDocumentBuilder() throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
+        return factory.newDocumentBuilder();
+    }
+
     @Override
     protected CIIMessage parseDocument(Object document) throws CIIReaderException {
         if (document instanceof Document) {


### PR DESCRIPTION
## Summary
- factor out secure DocumentBuilder creation in InvoiceReader
- reuse common builder in both `read` methods to avoid duplication

## Testing
- `mvn test` *(fails: Plugin org.codehaus.mojo:jaxb2-maven-plugin:3.3.0 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6891f910e9ac832e9ce618be248e7466