### PR TITLE
Validate message type after JSON deserialization

### DIFF
--- a/cii-messaging-parent/cii-service/src/main/java/com/cii/messaging/service/impl/CIIMessagingServiceImpl.java
+++ b/cii-messaging-parent/cii-service/src/main/java/com/cii/messaging/service/impl/CIIMessagingServiceImpl.java
@@ -147,6 +147,8 @@ public class CIIMessagingServiceImpl implements CIIMessagingService {
             // Ensure message type is set correctly
             if (message.getMessageType() == null) {
                 message.setMessageType(messageType);
+            } else if (message.getMessageType() != messageType) {
+                throw new ServiceException("Message type mismatch: expected " + messageType + " but found " + message.getMessageType());
             }
             return message;
         } catch (Exception e) {


### PR DESCRIPTION
## Summary
- verify that the deserialized message's type matches the expected type
- raise a ServiceException when a mismatch is detected

## Testing
- `mvn test` *(fails: Plugin org.codehaus.mojo:jaxb2-maven-plugin:3.3.0 or one of its dependencies could not be resolved: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6891f90cd524832ea9af902821abd846