### PR TITLE
Handle invalid schema version in CLI

### DIFF
--- a/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/ValidateCommand.java
+++ b/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/ValidateCommand.java
@@ -7,6 +7,7 @@ import picocli.CommandLine.*;
 import java.io.File;
 import java.util.concurrent.Callable;
 import java.util.List;
+import java.util.Arrays;
 
 @Command(
     name = "validate",
@@ -30,7 +31,13 @@ public class ValidateCommand implements Callable<Integer> {
         int totalFiles = inputFiles.length;
         int validFiles = 0;
         
-        SchemaVersion version = SchemaVersion.valueOf(schemaVersion.toUpperCase());
+        SchemaVersion version;
+        try {
+            version = SchemaVersion.valueOf(schemaVersion.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            System.err.println("Invalid schema version: " + schemaVersion + ". Allowed values: " + Arrays.toString(SchemaVersion.values()));
+            return 1;
+        }
         System.out.println("Validating " + totalFiles + " file(s) against " + version.getVersion() + "...\n");
 
         for (File file : inputFiles) {


### PR DESCRIPTION
## Summary
- handle invalid schema version input

## Testing
- `mvn test` *(fails: Plugin org.codehaus.mojo:jaxb2-maven-plugin:3.3.0 or one of its dependencies could not be resolved: Could not transfer artifact org.codehaus.mojo:jaxb2-maven-plugin:pom:3.3.0 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6891f90ed5a0832ebba37781a7a04cca