### PR TITLE
Ensure tax calculations use consistent rounding

### DIFF
--- a/cii-messaging-parent/cii-service/src/main/java/com/cii/messaging/service/impl/CIIMessagingServiceImpl.java
+++ b/cii-messaging-parent/cii-service/src/main/java/com/cii/messaging/service/impl/CIIMessagingServiceImpl.java
@@ -15,6 +15,7 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -326,8 +327,8 @@ public class CIIMessagingServiceImpl implements CIIMessagingService {
                 if (item.getTaxRate() != null) {
                     BigDecimal tax = item.getLineAmount()
                             .multiply(item.getTaxRate())
-                            .divide(BigDecimal.valueOf(100));
-                    taxTotal = taxTotal.add(tax);
+                            .divide(BigDecimal.valueOf(100), 2, RoundingMode.HALF_UP);
+                    taxTotal = taxTotal.add(tax).setScale(2, RoundingMode.HALF_UP);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Round BigDecimal tax computations using HALF_UP mode
- Recompute tax totals using rounded values for stable financial calculations

## Testing
- `mvn test` *(fails: Plugin org.codehaus.mojo:jaxb2-maven-plugin:3.3.0 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6891f908e9f4832eaa407f81ff793514