### PR TITLE
Disable DTD processing in reader factory

### DIFF
--- a/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/CIIReaderFactory.java
+++ b/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/CIIReaderFactory.java
@@ -28,9 +28,13 @@ public class CIIReaderFactory {
     }
 
     public static CIIReader createReader(String xmlContent) throws CIIReaderException {
+        XMLInputFactory factory = XMLInputFactory.newFactory();
+        factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+        factory.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
+
+        XMLStreamReader reader = null;
         try {
-            XMLStreamReader reader = XMLInputFactory.newFactory()
-                    .createXMLStreamReader(new StringReader(xmlContent));
+            reader = factory.createXMLStreamReader(new StringReader(xmlContent));
             while (reader.hasNext()) {
                 if (reader.next() == XMLStreamConstants.START_ELEMENT) {
                     String localName = reader.getLocalName();
@@ -50,6 +54,14 @@ public class CIIReaderFactory {
             }
         } catch (XMLStreamException e) {
             throw new CIIReaderException("Invalid XML content", e);
+        } finally {
+            if (reader != null) {
+                try {
+                    reader.close();
+                } catch (XMLStreamException e) {
+                    // ignore
+                }
+            }
         }
         throw new CIIReaderException("Unable to detect message type from XML content");
     }


### PR DESCRIPTION
## Summary
- prevent XML external entities by disabling DTD and external entity support in `CIIReaderFactory`
- ensure `XMLStreamReader` is closed with a try/finally block

## Testing
- `mvn -q test` *(fails: PluginResolutionException - Network is unreachable)*
- `mvn -q -pl cii-reader test` *(fails: PluginResolutionException - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6891f90723bc832ebd6f2bcd13bb786d