### PR TITLE
Ensure output directories exist before writing

### DIFF
--- a/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/ConvertCommand.java
+++ b/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/ConvertCommand.java
@@ -42,6 +42,11 @@ public class ConvertCommand implements Callable<Integer> {
         try {
             String inputContent = Files.readString(inputFile.toPath(), StandardCharsets.UTF_8);
             boolean isInputJson = inputContent.trim().startsWith("{");
+
+            java.io.File parent = outputFile.getParentFile();
+            if (parent != null) {
+                parent.mkdirs();
+            }
             
             if ("JSON".equalsIgnoreCase(targetFormat)) {
                 if (isInputJson) {

--- a/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/GenerateCommand.java
+++ b/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/GenerateCommand.java
@@ -67,6 +67,12 @@ public class GenerateCommand implements Callable<Integer> {
             message = createSampleMessage();
         }
         
+        // Ensure output directory exists
+        java.io.File parent = outputFile.getParentFile();
+        if (parent != null) {
+            parent.mkdirs();
+        }
+
         // Write output
         if ("JSON".equalsIgnoreCase(format)) {
             String json = service.convertToJson(message);

--- a/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/ParseCommand.java
+++ b/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/ParseCommand.java
@@ -44,6 +44,10 @@ public class ParseCommand implements Callable<Integer> {
             }
             
             if (outputFile != null) {
+                java.io.File parent = outputFile.getParentFile();
+                if (parent != null) {
+                    parent.mkdirs();
+                }
                 java.nio.file.Files.writeString(outputFile.toPath(), output,
                         java.nio.charset.StandardCharsets.UTF_8);
                 System.out.println("Output saved to: " + outputFile.getAbsolutePath());

--- a/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/impl/AbstractCIIWriter.java
+++ b/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/impl/AbstractCIIWriter.java
@@ -28,9 +28,13 @@ public abstract class AbstractCIIWriter implements CIIWriter {
     
     protected abstract void initializeJAXBContext() throws JAXBException;
     protected abstract Object createDocument(CIIMessage message) throws CIIWriterException;
-    
+
     @Override
     public void write(CIIMessage message, File outputFile) throws CIIWriterException {
+        java.io.File parent = outputFile.getParentFile();
+        if (parent != null && !parent.exists()) {
+            parent.mkdirs();
+        }
         try (OutputStream os = new FileOutputStream(outputFile)) {
             write(message, os);
         } catch (IOException e) {


### PR DESCRIPTION
## Summary
- Create parent directory before file writes in CLI commands
- Create parent directory in `AbstractCIIWriter` `write` method

## Testing
- `mvn test` *(fails: Plugin org.codehaus.mojo:jaxb2-maven-plugin:3.3.0 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6891f8fcf278832eb8f72b44940c3018