### PR TITLE
Add SLF4J test binding for cii-reader

### DIFF
--- a/cii-messaging-parent/cii-reader/pom.xml
+++ b/cii-messaging-parent/cii-reader/pom.xml
@@ -43,6 +43,12 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
         <!-- ADD LOMBOK DEPENDENCY -->
         <dependency>
             <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
## Summary
- add slf4j-simple as test-scoped dependency to supply SLF4J binding during tests

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-compiler-plugin:3.11.0 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6892055bf07c832ea63aa151cced45b0