### PR TITLE
feat: add reader dependency to validator

### DIFF
--- a/cii-messaging-parent/cii-validator/pom.xml
+++ b/cii-messaging-parent/cii-validator/pom.xml
@@ -25,6 +25,11 @@
         </dependency>
         <dependency>
             <groupId>com.cii.messaging</groupId>
+            <artifactId>cii-reader</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.cii.messaging</groupId>
             <artifactId>cii-writer</artifactId>
             <version>${project.version}</version>
         </dependency>


### PR DESCRIPTION
## Summary
- include `cii-reader` dependency in `cii-validator` module

## Testing
- `mvn clean install -rf :cii-validator` *(fails: Plugin org.apache.maven.plugins:maven-clean-plugin:3.2.0 or one of its dependencies could not be resolved: Could not transfer artifact ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68920555e7a8832ebbf939a45d0e5c3a