### PR TITLE
feat: use D16B namespace for invoice

### DIFF
--- a/cii-messaging-parent/cii-samples/src/main/resources/samples/invoice-sample.xml
+++ b/cii-messaging-parent/cii-samples/src/main/resources/samples/invoice-sample.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
-                          xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
-                          xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:16B"
+                          xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:16B"
+                          xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:16B">
     <rsm:ExchangedDocument>
         <ram:ID>INV-2024-001</ram:ID>
         <ram:TypeCode>380</ram:TypeCode>

--- a/cii-messaging-parent/cii-samples/src/test/java/com/cii/messaging/integration/CIIIntegrationTest.java
+++ b/cii-messaging-parent/cii-samples/src/test/java/com/cii/messaging/integration/CIIIntegrationTest.java
@@ -116,7 +116,7 @@ class CIIIntegrationTest {
     void testValidationWithErrors() throws Exception {
         String invalidXml = """
             <?xml version="1.0" encoding="UTF-8"?>
-            <rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100">
+            <rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:16B">
                 <rsm:ExchangedDocument>
                     <!-- Missing required elements -->
                 </rsm:ExchangedDocument>

--- a/cii-messaging-parent/cii-validator/src/main/resources/schematron/D16B.xslt
+++ b/cii-messaging-parent/cii-validator/src/main/resources/schematron/D16B.xslt
@@ -2,8 +2,8 @@
 <xsl:stylesheet version="2.0"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-    xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
-    xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100">
+    xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:16B"
+    xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:16B">
   <xsl:output method="xml" indent="yes"/>
   <xsl:template match="/">
     <svrl:schematron-output>

--- a/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/validator/impl/SchematronValidatorTest.java
+++ b/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/validator/impl/SchematronValidatorTest.java
@@ -24,8 +24,8 @@ class SchematronValidatorTest {
     @Test
     void missingIdAndLineItemProducesWarningAndError() {
         String xml = """
-                <rsm:CrossIndustryInvoice xmlns:rsm=\"urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100\"
-                    xmlns:ram=\"urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100\">
+                <rsm:CrossIndustryInvoice xmlns:rsm=\"urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:16B\"
+                    xmlns:ram=\"urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:16B\">
                     <rsm:ExchangedDocument/>
                     <rsm:SupplyChainTradeTransaction/>
                 </rsm:CrossIndustryInvoice>

--- a/cii-messaging-parent/cii-validator/src/test/resources/invoice-sample.xml
+++ b/cii-messaging-parent/cii-validator/src/test/resources/invoice-sample.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
-                          xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
-                          xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:16B"
+                          xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:16B"
+                          xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:16B">
     <rsm:ExchangedDocument>
         <ram:ID>INV-2024-001</ram:ID>
         <ram:TypeCode>380</ram:TypeCode>

--- a/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/impl/InvoiceWriter.java
+++ b/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/impl/InvoiceWriter.java
@@ -56,11 +56,16 @@ public class InvoiceWriter extends AbstractCIIWriter {
             DocumentBuilder builder = factory.newDocumentBuilder();
             Document doc = builder.newDocument();
             
-            // Create root element
-            Element root = doc.createElementNS("urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100", "rsm:CrossIndustryInvoice");
-            root.setAttribute("xmlns:rsm", "urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100");
-            root.setAttribute("xmlns:ram", "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100");
-            root.setAttribute("xmlns:udt", "urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100");
+            // Create root element for D16B namespace
+            Element root = doc.createElementNS(
+                    "urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:16B",
+                    "rsm:CrossIndustryInvoice");
+            root.setAttribute("xmlns:rsm",
+                    "urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:16B");
+            root.setAttribute("xmlns:ram",
+                    "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:16B");
+            root.setAttribute("xmlns:udt",
+                    "urn:un:unece:uncefact:data:standard:UnqualifiedDataType:16B");
             doc.appendChild(root);
             
             // Add ExchangedDocument


### PR DESCRIPTION
## Summary
- switch invoice writer to D16B namespaces
- update D16B schematron and samples to same namespace

## Testing
- `mvn -pl :cii-writer -am package -DskipTests` *(fails: Plugin org.codehaus.mojo:jaxb2-maven-plugin:3.3.0 or one of its dependencies could not be resolved)*
- `mvn -rf :cii-samples test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68920ef799f0832e9eb7a49ad97878d0