### PR TITLE
Add Jackson Java Time module

### DIFF
--- a/cii-messaging-parent/cii-service/pom.xml
+++ b/cii-messaging-parent/cii-service/pom.xml
@@ -47,6 +47,10 @@
             <artifactId>jackson-dataformat-xml</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/cii-messaging-parent/pom.xml
+++ b/cii-messaging-parent/pom.xml
@@ -100,6 +100,11 @@
 				<artifactId>jackson-dataformat-xml</artifactId>
 				<version>${jackson.version}</version>
 			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.datatype</groupId>
+				<artifactId>jackson-datatype-jsr310</artifactId>
+				<version>${jackson.version}</version>
+			</dependency>
 
 			<!-- Logging -->
 			<dependency>


### PR DESCRIPTION
## Summary
- include `jackson-datatype-jsr310` for Java time support
- manage the Java Time module version in the parent POM

## Testing
- `mvn -pl cii-service -am install` *(fails: Plugin org.apache.maven.plugins:maven-install-plugin:3.1.2 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-install-plugin:pom:3.1.2 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*
- `mvn -pl cii-samples test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68920ef24cc0832e8b026e1c7f5caeec