### PR TITLE
Add no-args constructors to model classes for Jackson

### DIFF
--- a/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/Address.java
+++ b/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/Address.java
@@ -1,10 +1,16 @@
 package com.cii.messaging.model;
 
-import lombok.Data;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.jackson.Jacksonized;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Jacksonized
 public class Address {
     private String street;
     private String city;

--- a/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/CIIMessage.java
+++ b/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/CIIMessage.java
@@ -1,12 +1,18 @@
 package com.cii.messaging.model;
 
-import lombok.Data;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.jackson.Jacksonized;
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Jacksonized
 public class CIIMessage {
     private String messageId;
     private MessageType messageType;

--- a/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/DeliveryInformation.java
+++ b/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/DeliveryInformation.java
@@ -1,11 +1,17 @@
 package com.cii.messaging.model;
 
-import lombok.Data;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.jackson.Jacksonized;
 import java.time.LocalDate;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Jacksonized
 public class DeliveryInformation {
     private LocalDate deliveryDate;
     private String deliveryLocationId;

--- a/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/DocumentHeader.java
+++ b/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/DocumentHeader.java
@@ -1,11 +1,17 @@
 package com.cii.messaging.model;
 
-import lombok.Data;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.jackson.Jacksonized;
 import java.time.LocalDate;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Jacksonized
 public class DocumentHeader {
     private String documentNumber;
     private LocalDate documentDate;

--- a/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/LineItem.java
+++ b/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/LineItem.java
@@ -1,11 +1,17 @@
 package com.cii.messaging.model;
 
-import lombok.Data;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.jackson.Jacksonized;
 import java.math.BigDecimal;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Jacksonized
 public class LineItem {
     private String lineNumber;
     private String productId;

--- a/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/PaymentTerms.java
+++ b/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/PaymentTerms.java
@@ -1,11 +1,17 @@
 package com.cii.messaging.model;
 
-import lombok.Data;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.jackson.Jacksonized;
 import java.time.LocalDate;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Jacksonized
 public class PaymentTerms {
     private String description;
     private LocalDate dueDate;

--- a/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/TotalsInformation.java
+++ b/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/TotalsInformation.java
@@ -1,11 +1,17 @@
 package com.cii.messaging.model;
 
-import lombok.Data;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.jackson.Jacksonized;
 import java.math.BigDecimal;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Jacksonized
 public class TotalsInformation {
     private BigDecimal lineTotalAmount;
     private BigDecimal taxBasisAmount;


### PR DESCRIPTION
## Summary
- ensure CII model classes have public constructors for Jackson by adding `@NoArgsConstructor`
- supplement with `@AllArgsConstructor` and `@Jacksonized` to support Lombok builders

## Testing
- `mvn -pl cii-samples test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68921897be74832eb91126c125691441