### PR TITLE
Use compact JSON output in CIIMessagingService

### DIFF
--- a/cii-messaging-parent/cii-service/src/main/java/com/cii/messaging/service/impl/CIIMessagingServiceImpl.java
+++ b/cii-messaging-parent/cii-service/src/main/java/com/cii/messaging/service/impl/CIIMessagingServiceImpl.java
@@ -135,7 +135,7 @@ public class CIIMessagingServiceImpl implements CIIMessagingService {
     @Override
     public String convertToJson(CIIMessage message) throws ServiceException {
         try {
-            return jsonMapper.writerWithDefaultPrettyPrinter().writeValueAsString(message);
+            return jsonMapper.writeValueAsString(message);
         } catch (Exception e) {
             throw new ServiceException("Failed to convert message to JSON", e);
         }


### PR DESCRIPTION
## Summary
- switch `CIIMessagingServiceImpl.convertToJson` to use `writeValueAsString` for compact JSON output

## Testing
- `mvn -pl cii-samples test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68921882daa0832eb4c4cbe74f732a88