### PR TITLE
Implement file-based validation and add tests

### DIFF
--- a/cii-messaging-parent/cii-validator/src/main/java/com/cii/messaging/validator/impl/BusinessRulesValidator.java
+++ b/cii-messaging-parent/cii-validator/src/main/java/com/cii/messaging/validator/impl/BusinessRulesValidator.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
@@ -19,11 +20,12 @@ public class BusinessRulesValidator implements CIIValidator {
 
     @Override
     public ValidationResult validate(File xmlFile) {
-        // Implement business rules validation
-        return ValidationResult.builder()
-                .valid(true)
-                .validatedAgainst("Business Rules")
-                .build();
+        try (InputStream is = Files.newInputStream(xmlFile.toPath())) {
+            String xmlContent = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+            return validate(xmlContent);
+        } catch (IOException e) {
+            return buildFatalResult("Failed to read XML from file: " + e.getMessage());
+        }
     }
 
     @Override

--- a/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/validator/impl/BusinessRulesValidatorFileTest.java
+++ b/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/validator/impl/BusinessRulesValidatorFileTest.java
@@ -1,0 +1,30 @@
+package com.cii.messaging.validator.impl;
+
+import com.cii.messaging.validator.ValidationResult;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BusinessRulesValidatorFileTest {
+
+    @Test
+    void validateFileValidXml() {
+        BusinessRulesValidator validator = new BusinessRulesValidator();
+        File file = Path.of("src", "test", "resources", "invoice-sample.xml").toFile();
+        ValidationResult result = validator.validate(file);
+        assertTrue(result.isValid());
+        assertTrue(result.getErrors().isEmpty());
+    }
+
+    @Test
+    void validateFileMissingBuyerReferenceProducesError() {
+        BusinessRulesValidator validator = new BusinessRulesValidator();
+        File file = Path.of("src", "test", "resources", "invoice-missing-buyer-ref.xml").toFile();
+        ValidationResult result = validator.validate(file);
+        assertFalse(result.isValid());
+        assertTrue(result.getErrors().stream().anyMatch(e -> "BR-05".equals(e.getRule())));
+    }
+}

--- a/cii-messaging-parent/cii-validator/src/test/resources/invoice-missing-buyer-ref.xml
+++ b/cii-messaging-parent/cii-validator/src/test/resources/invoice-missing-buyer-ref.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:16B"
+                          xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:16B"
+                          xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:16B">
+    <rsm:ExchangedDocument>
+        <ram:ID>INV-2024-001</ram:ID>
+        <ram:TypeCode>380</ram:TypeCode>
+        <ram:IssueDateTime>
+            <udt:DateTimeString format="102">20240201120000</udt:DateTimeString>
+        </ram:IssueDateTime>
+    </rsm:ExchangedDocument>
+    <rsm:SupplyChainTradeTransaction>
+        <ram:IncludedSupplyChainTradeLineItem>
+            <ram:AssociatedDocumentLineDocument>
+                <ram:LineID>1</ram:LineID>
+            </ram:AssociatedDocumentLineDocument>
+            <ram:SpecifiedTradeProduct>
+                <ram:GlobalID schemeID="GTIN">4012345678901</ram:GlobalID>
+                <ram:Name>Industrial Widget Type A</ram:Name>
+            </ram:SpecifiedTradeProduct>
+            <ram:SpecifiedLineTradeAgreement>
+                <ram:NetPriceProductTradePrice>
+                    <ram:ChargeAmount>150.00</ram:ChargeAmount>
+                </ram:NetPriceProductTradePrice>
+            </ram:SpecifiedLineTradeAgreement>
+            <ram:SpecifiedLineTradeDelivery>
+                <ram:BilledQuantity unitCode="EA">100</ram:BilledQuantity>
+            </ram:SpecifiedLineTradeDelivery>
+            <ram:SpecifiedLineTradeSettlement>
+                <ram:ApplicableTradeTax>
+                    <ram:TypeCode>VAT</ram:TypeCode>
+                    <ram:CategoryCode>S</ram:CategoryCode>
+                    <ram:RateApplicablePercent>20</ram:RateApplicablePercent>
+                </ram:ApplicableTradeTax>
+                <ram:SpecifiedTradeSettlementLineMonetarySummation>
+                    <ram:LineTotalAmount>15000.00</ram:LineTotalAmount>
+                </ram:SpecifiedTradeSettlementLineMonetarySummation>
+            </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+        <ram:ApplicableHeaderTradeAgreement>
+            <ram:SellerTradeParty>
+                <ram:ID>DE123456789</ram:ID>
+                <ram:Name>Seller Company GmbH</ram:Name>
+                <ram:DefinedTradeContact>
+                    <ram:PersonName>John Doe</ram:PersonName>
+                    <ram:TelephoneUniversalCommunication>
+                        <ram:CompleteNumber>+49 30 12345678</ram:CompleteNumber>
+                    </ram:TelephoneUniversalCommunication>
+                    <ram:EmailURIUniversalCommunication>
+                        <ram:URIID>info@seller-company.de</ram:URIID>
+                    </ram:EmailURIUniversalCommunication>
+                </ram:DefinedTradeContact>
+                <ram:PostalTradeAddress>
+                    <ram:PostcodeCode>10115</ram:PostcodeCode>
+                    <ram:LineOne>Hauptstraße 123</ram:LineOne>
+                    <ram:CityName>Berlin</ram:CityName>
+                    <ram:CountryID>DE</ram:CountryID>
+                </ram:PostalTradeAddress>
+                <ram:SpecifiedTaxRegistration>
+                    <ram:ID schemeID="VA">DE123456789</ram:ID>
+                </ram:SpecifiedTaxRegistration>
+            </ram:SellerTradeParty>
+            <ram:BuyerTradeParty>
+                <ram:ID>FR987654321</ram:ID>
+                <ram:Name>Buyer Company SAS</ram:Name>
+                <ram:PostalTradeAddress>
+                    <ram:PostcodeCode>75001</ram:PostcodeCode>
+                    <ram:LineOne>Rue de la Paix 456</ram:LineOne>
+                    <ram:CityName>Paris</ram:CityName>
+                    <ram:CountryID>FR</ram:CountryID>
+                </ram:PostalTradeAddress>
+            </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+        <ram:ApplicableHeaderTradeDelivery>
+            <ram:ActualDeliverySupplyChainEvent>
+                <ram:OccurrenceDateTime>
+                    <udt:DateTimeString format="102">20240130</udt:DateTimeString>
+                </ram:OccurrenceDateTime>
+            </ram:ActualDeliverySupplyChainEvent>
+        </ram:ApplicableHeaderTradeDelivery>
+        <ram:ApplicableHeaderTradeSettlement>
+            <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
+            <ram:SpecifiedTradeSettlementPaymentTerms>
+                <ram:Description>30 days net</ram:Description>
+                <ram:DueDateDateTime>
+                    <udt:DateTimeString format="102">20240303</udt:DateTimeString>
+                </ram:DueDateDateTime>
+            </ram:SpecifiedTradeSettlementPaymentTerms>
+            <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+                <ram:LineTotalAmount>15000.00</ram:LineTotalAmount>
+                <ram:TaxBasisTotalAmount>15000.00</ram:TaxBasisTotalAmount>
+                <ram:TaxTotalAmount currencyID="EUR">3000.00</ram:TaxTotalAmount>
+                <ram:GrandTotalAmount>18000.00</ram:GrandTotalAmount>
+                <ram:DuePayableAmount>18000.00</ram:DuePayableAmount>
+            </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        </ram:ApplicableHeaderTradeSettlement>
+    </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>


### PR DESCRIPTION
## Summary
- Ensure `BusinessRulesValidator` reads XML files and applies existing string-based rules
- Add tests for file-based validation, including missing buyer reference scenarios

## Testing
- `mvn -q -pl cii-validator -am test` *(fails: Plugin org.codehaus.mojo:jaxb2-maven-plugin:3.3.0 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6892219b94b4832ebfa871cff269a2c2