### PR TITLE
Add CIIMessage support in XSD and Schematron validators

### DIFF
--- a/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/validator/impl/SchematronValidatorTest.java
+++ b/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/validator/impl/SchematronValidatorTest.java
@@ -1,10 +1,15 @@
 package com.cii.messaging.validator.impl;
 
+import com.cii.messaging.model.CIIMessage;
+import com.cii.messaging.model.MessageType;
+import com.cii.messaging.reader.CIIReader;
+import com.cii.messaging.reader.CIIReaderFactory;
 import com.cii.messaging.validator.ValidationResult;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.LocalDateTime;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -34,6 +39,28 @@ class SchematronValidatorTest {
         assertFalse(result.isValid());
         assertEquals(1, result.getErrors().size());
         assertEquals(1, result.getWarnings().size());
+    }
+
+    @Test
+    void validCIIMessageHasNoErrors() throws Exception {
+        String xml = Files.readString(Path.of("src", "test", "resources", "invoice-sample.xml"));
+        CIIReader reader = CIIReaderFactory.createReader(MessageType.INVOICE);
+        CIIMessage message = reader.read(xml);
+        ValidationResult result = validator.validate(message);
+        assertTrue(result.isValid());
+        assertTrue(result.getErrors().isEmpty());
+    }
+
+    @Test
+    void invalidCIIMessageProducesErrors() {
+        CIIMessage message = CIIMessage.builder()
+                .messageId("INV-1")
+                .messageType(MessageType.INVOICE)
+                .creationDateTime(LocalDateTime.now())
+                .build();
+        ValidationResult result = validator.validate(message);
+        assertFalse(result.isValid());
+        assertFalse(result.getErrors().isEmpty());
     }
 }
 

--- a/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/validator/impl/XSDValidatorTest.java
+++ b/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/validator/impl/XSDValidatorTest.java
@@ -1,0 +1,41 @@
+package com.cii.messaging.validator.impl;
+
+import com.cii.messaging.model.CIIMessage;
+import com.cii.messaging.model.MessageType;
+import com.cii.messaging.reader.CIIReader;
+import com.cii.messaging.reader.CIIReaderFactory;
+import com.cii.messaging.validator.ValidationResult;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class XSDValidatorTest {
+
+    @Test
+    void validateCIIMessageValid() throws Exception {
+        String xml = Files.readString(Path.of("src", "test", "resources", "invoice-sample.xml"));
+        CIIReader reader = CIIReaderFactory.createReader(MessageType.INVOICE);
+        CIIMessage message = reader.read(xml);
+        XSDValidator validator = new XSDValidator();
+        ValidationResult result = validator.validate(message);
+        assertTrue(result.isValid());
+        assertTrue(result.getErrors().isEmpty());
+    }
+
+    @Test
+    void validateCIIMessageInvalid() {
+        CIIMessage message = CIIMessage.builder()
+                .messageId("INV-1")
+                .messageType(MessageType.INVOICE)
+                .creationDateTime(LocalDateTime.now())
+                .build();
+        XSDValidator validator = new XSDValidator();
+        ValidationResult result = validator.validate(message);
+        assertFalse(result.isValid());
+        assertFalse(result.getErrors().isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- allow XSD and Schematron validators to accept `CIIMessage` objects by serializing them to XML before validation
- test that both validators succeed on valid messages and report errors on invalid messages

## Testing
- `mvn -q -pl cii-validator -am test` *(fails: Plugin org.codehaus.mojo:jaxb2-maven-plugin:3.3.0 or one of its dependencies could not be resolved: Could not transfer artifact org.codehaus.mojo:jaxb2-maven-plugin:pom:3.3.0 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689221a4d1dc832e9b310745c612ed3e