### PR TITLE
Parse TaxBasisTotalAmount in InvoiceReader

### DIFF
--- a/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/impl/InvoiceReader.java
+++ b/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/impl/InvoiceReader.java
@@ -133,6 +133,7 @@ public class InvoiceReader extends AbstractCIIReader {
     private TotalsInformation extractInvoiceTotals(Document doc) {
         return TotalsInformation.builder()
                 .lineTotalAmount(parseBigDecimal(extractTextContent(doc, "LineTotalAmount")))
+                .taxBasisAmount(parseBigDecimal(extractTextContent(doc, "TaxBasisTotalAmount")))
                 .taxTotalAmount(parseBigDecimal(extractTextContent(doc, "TaxTotalAmount")))
                 .grandTotalAmount(parseBigDecimal(extractTextContent(doc, "GrandTotalAmount")))
                 .duePayableAmount(parseBigDecimal(extractTextContent(doc, "DuePayableAmount")))

--- a/cii-messaging-parent/cii-reader/src/test/java/com/cii/messaging/reader/InvoiceReaderTest.java
+++ b/cii-messaging-parent/cii-reader/src/test/java/com/cii/messaging/reader/InvoiceReaderTest.java
@@ -1,0 +1,25 @@
+package com.cii.messaging.reader;
+
+import com.cii.messaging.model.CIIMessage;
+import com.cii.messaging.reader.impl.InvoiceReader;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.math.BigDecimal;
+import java.net.URL;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class InvoiceReaderTest {
+
+    @Test
+    void extractsTaxBasisAmount() throws Exception {
+        InvoiceReader reader = new InvoiceReader();
+        URL resource = getClass().getResource("/invoice-sample.xml");
+        assertNotNull(resource);
+        File file = new File(resource.toURI());
+        CIIMessage message = reader.read(file);
+        assertNotNull(message.getTotals());
+        assertEquals(new BigDecimal("15000.00"), message.getTotals().getTaxBasisAmount());
+    }
+}

--- a/cii-messaging-parent/cii-reader/src/test/resources/invoice-sample.xml
+++ b/cii-messaging-parent/cii-reader/src/test/resources/invoice-sample.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:16B"
+                          xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:16B"
+                          xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:16B">
+    <rsm:ExchangedDocument>
+        <ram:ID>INV-2024-001</ram:ID>
+        <ram:TypeCode>380</ram:TypeCode>
+        <ram:IssueDateTime>
+            <udt:DateTimeString format="102">20240201120000</udt:DateTimeString>
+        </ram:IssueDateTime>
+    </rsm:ExchangedDocument>
+    <rsm:SupplyChainTradeTransaction>
+        <ram:IncludedSupplyChainTradeLineItem>
+            <ram:AssociatedDocumentLineDocument>
+                <ram:LineID>1</ram:LineID>
+            </ram:AssociatedDocumentLineDocument>
+            <ram:SpecifiedTradeProduct>
+                <ram:GlobalID schemeID="GTIN">4012345678901</ram:GlobalID>
+                <ram:Name>Industrial Widget Type A</ram:Name>
+            </ram:SpecifiedTradeProduct>
+            <ram:SpecifiedLineTradeAgreement>
+                <ram:NetPriceProductTradePrice>
+                    <ram:ChargeAmount>150.00</ram:ChargeAmount>
+                </ram:NetPriceProductTradePrice>
+            </ram:SpecifiedLineTradeAgreement>
+            <ram:SpecifiedLineTradeDelivery>
+                <ram:BilledQuantity unitCode="EA">100</ram:BilledQuantity>
+            </ram:SpecifiedLineTradeDelivery>
+            <ram:SpecifiedLineTradeSettlement>
+                <ram:ApplicableTradeTax>
+                    <ram:TypeCode>VAT</ram:TypeCode>
+                    <ram:CategoryCode>S</ram:CategoryCode>
+                    <ram:RateApplicablePercent>20</ram:RateApplicablePercent>
+                </ram:ApplicableTradeTax>
+                <ram:SpecifiedTradeSettlementLineMonetarySummation>
+                    <ram:LineTotalAmount>15000.00</ram:LineTotalAmount>
+                </ram:SpecifiedTradeSettlementLineMonetarySummation>
+            </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+        <ram:ApplicableHeaderTradeAgreement>
+            <ram:BuyerReference>BUY-REF-2024-001</ram:BuyerReference>
+            <ram:SellerTradeParty>
+                <ram:ID>DE123456789</ram:ID>
+                <ram:Name>Seller Company GmbH</ram:Name>
+                <ram:DefinedTradeContact>
+                    <ram:PersonName>John Doe</ram:PersonName>
+                    <ram:TelephoneUniversalCommunication>
+                        <ram:CompleteNumber>+49 30 12345678</ram:CompleteNumber>
+                    </ram:TelephoneUniversalCommunication>
+                    <ram:EmailURIUniversalCommunication>
+                        <ram:URIID>info@seller-company.de</ram:URIID>
+                    </ram:EmailURIUniversalCommunication>
+                </ram:DefinedTradeContact>
+                <ram:PostalTradeAddress>
+                    <ram:PostcodeCode>10115</ram:PostcodeCode>
+                    <ram:LineOne>Hauptstraße 123</ram:LineOne>
+                    <ram:CityName>Berlin</ram:CityName>
+                    <ram:CountryID>DE</ram:CountryID>
+                </ram:PostalTradeAddress>
+                <ram:SpecifiedTaxRegistration>
+                    <ram:ID schemeID="VA">DE123456789</ram:ID>
+                </ram:SpecifiedTaxRegistration>
+            </ram:SellerTradeParty>
+            <ram:BuyerTradeParty>
+                <ram:ID>FR987654321</ram:ID>
+                <ram:Name>Buyer Company SAS</ram:Name>
+                <ram:PostalTradeAddress>
+                    <ram:PostcodeCode>75001</ram:PostcodeCode>
+                    <ram:LineOne>Rue de la Paix 456</ram:LineOne>
+                    <ram:CityName>Paris</ram:CityName>
+                    <ram:CountryID>FR</ram:CountryID>
+                </ram:PostalTradeAddress>
+            </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+        <ram:ApplicableHeaderTradeDelivery>
+            <ram:ActualDeliverySupplyChainEvent>
+                <ram:OccurrenceDateTime>
+                    <udt:DateTimeString format="102">20240130</udt:DateTimeString>
+                </ram:OccurrenceDateTime>
+            </ram:ActualDeliverySupplyChainEvent>
+        </ram:ApplicableHeaderTradeDelivery>
+        <ram:ApplicableHeaderTradeSettlement>
+            <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
+            <ram:SpecifiedTradeSettlementPaymentTerms>
+                <ram:Description>30 days net</ram:Description>
+                <ram:DueDateDateTime>
+                    <udt:DateTimeString format="102">20240303</udt:DateTimeString>
+                </ram:DueDateDateTime>
+            </ram:SpecifiedTradeSettlementPaymentTerms>
+            <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+                <ram:LineTotalAmount>15000.00</ram:LineTotalAmount>
+                <ram:TaxBasisTotalAmount>15000.00</ram:TaxBasisTotalAmount>
+                <ram:TaxTotalAmount currencyID="EUR">3000.00</ram:TaxTotalAmount>
+                <ram:GrandTotalAmount>18000.00</ram:GrandTotalAmount>
+                <ram:DuePayableAmount>18000.00</ram:DuePayableAmount>
+            </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        </ram:ApplicableHeaderTradeSettlement>
+    </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>


### PR DESCRIPTION
## Summary
- parse `TaxBasisTotalAmount` in `InvoiceReader` to populate `TotalsInformation`
- test reading a sample invoice to ensure the tax basis amount is captured

## Testing
- `mvn -q -pl cii-reader -am test` *(fails: Could not transfer artifact org.codehaus.mojo:jaxb2-maven-plugin:pom:3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_689224e63284832ea989561ea8702ac3