### PR TITLE
Extract tax fields from invoice line items

### DIFF
--- a/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/LineItem.java
+++ b/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/LineItem.java
@@ -22,4 +22,5 @@ public class LineItem {
     private BigDecimal lineAmount;
     private BigDecimal taxRate;
     private String taxCategory;
+    private String taxTypeCode;
 }

--- a/cii-messaging-parent/cii-model/src/test/java/com/cii/messaging/model/LineItemTest.java
+++ b/cii-messaging-parent/cii-model/src/test/java/com/cii/messaging/model/LineItemTest.java
@@ -20,6 +20,7 @@ class LineItemTest {
                 .lineAmount(new BigDecimal("20"))
                 .taxRate(new BigDecimal("0.2"))
                 .taxCategory("VAT")
+                .taxTypeCode("VAT")
                 .build();
 
         assertEquals("1", item.getLineNumber());
@@ -31,6 +32,7 @@ class LineItemTest {
         assertEquals(new BigDecimal("20"), item.getLineAmount());
         assertEquals(new BigDecimal("0.2"), item.getTaxRate());
         assertEquals("VAT", item.getTaxCategory());
+        assertEquals("VAT", item.getTaxTypeCode());
     }
 
     @Test
@@ -45,6 +47,7 @@ class LineItemTest {
                 .lineAmount(new BigDecimal("20"))
                 .taxRate(new BigDecimal("0.2"))
                 .taxCategory("VAT")
+                .taxTypeCode("VAT")
                 .build();
 
         LineItem item2 = LineItem.builder()
@@ -57,6 +60,7 @@ class LineItemTest {
                 .lineAmount(new BigDecimal("20"))
                 .taxRate(new BigDecimal("0.2"))
                 .taxCategory("VAT")
+                .taxTypeCode("VAT")
                 .build();
 
         LineItem item3 = LineItem.builder()
@@ -69,6 +73,7 @@ class LineItemTest {
                 .lineAmount(new BigDecimal("15"))
                 .taxRate(new BigDecimal("0.1"))
                 .taxCategory("VAT")
+                .taxTypeCode("VAT")
                 .build();
 
         assertEquals(item1, item2);

--- a/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/impl/InvoiceReader.java
+++ b/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/impl/InvoiceReader.java
@@ -127,6 +127,9 @@ public class InvoiceReader extends AbstractCIIReader {
                 .unitCode("EA") // Default
                 .unitPrice(parseBigDecimal(extractTextContent(lineElement, "ChargeAmount")))
                 .lineAmount(parseBigDecimal(extractTextContent(lineElement, "LineTotalAmount")))
+                .taxCategory(extractTextContent(lineElement, "CategoryCode"))
+                .taxRate(parseBigDecimal(extractTextContent(lineElement, "RateApplicablePercent")))
+                .taxTypeCode(extractTextContent(lineElement, "TypeCode"))
                 .build();
     }
     

--- a/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/impl/InvoiceWriter.java
+++ b/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/impl/InvoiceWriter.java
@@ -196,8 +196,9 @@ public class InvoiceWriter extends AbstractCIIWriter {
         
         // Line settlement
         Element lineSettlement = doc.createElement("ram:SpecifiedLineTradeSettlement");
-        if (lineItem.getTaxRate() != null || lineItem.getTaxCategory() != null) {
+        if (lineItem.getTaxRate() != null || lineItem.getTaxCategory() != null || lineItem.getTaxTypeCode() != null) {
             Element tradeTax = doc.createElement("ram:ApplicableTradeTax");
+            addElement(doc, tradeTax, "ram:TypeCode", lineItem.getTaxTypeCode());
             addAmountElement(doc, tradeTax, "ram:RateApplicablePercent", lineItem.getTaxRate());
             addElement(doc, tradeTax, "ram:CategoryCode", lineItem.getTaxCategory());
             lineSettlement.appendChild(tradeTax);


### PR DESCRIPTION
## Summary
- parse line-level tax category and rate in InvoiceReader
- support tax type code in LineItem and serialize in InvoiceWriter

## Testing
- `mvn -q -pl cii-model,cii-reader,cii-writer -am -Djaxb2.skip=true test` *(fails: Plugin org.codehaus.mojo:jaxb2-maven-plugin:3.3.0 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_689224eaf024832e8e796f9356eef36d