### PR TITLE
Allow overriding element helpers in InvoiceWriter

### DIFF
--- a/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/impl/InvoiceWriter.java
+++ b/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/impl/InvoiceWriter.java
@@ -209,7 +209,8 @@ public class InvoiceWriter extends AbstractCIIWriter {
         return lineElement;
     }
     
-    private void addElement(Document doc, Element parent, String name, String value) {
+    @Override
+    protected void addElement(Document doc, Element parent, String name, String value) {
         if (value != null && !value.isBlank()) {
             Element element = doc.createElement(name);
             element.setTextContent(value);
@@ -217,7 +218,8 @@ public class InvoiceWriter extends AbstractCIIWriter {
         }
     }
 
-    private void addAmountElement(Document doc, Element parent, String name, BigDecimal amount) {
+    @Override
+    protected void addAmountElement(Document doc, Element parent, String name, BigDecimal amount) {
         if (amount != null && amount.compareTo(BigDecimal.ZERO) != 0) {
             Element element = doc.createElement(name);
             element.setTextContent(amount.toPlainString());


### PR DESCRIPTION
## Summary
- annotate addElement and addAmountElement in InvoiceWriter with @Override and widen visibility to protected.

## Testing
- `mvn -pl cii-writer clean install` *(fails: Network is unreachable)*
- `mvn clean install` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6892f4521c08832e804ba10bf416ca28