### PR TITLE
feat: target invoice document ID

### DIFF
--- a/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/impl/InvoiceReader.java
+++ b/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/impl/InvoiceReader.java
@@ -71,7 +71,7 @@ public class InvoiceReader extends AbstractCIIReader {
         TradeParty seller = extractTradeParty(doc, "SellerTradeParty");
         TradeParty buyer = extractTradeParty(doc, "BuyerTradeParty");
         return CIIMessage.builder()
-                .messageId(extractTextContent(doc, "ID"))
+                .messageId(extractDocumentId(doc))
                 .messageType(MessageType.INVOICE)
                 .creationDateTime(LocalDateTime.now())
                 .senderPartyId(seller != null ? seller.getId() : null)
@@ -143,13 +143,25 @@ public class InvoiceReader extends AbstractCIIReader {
     
     private DocumentHeader extractInvoiceHeader(Document doc) {
         return DocumentHeader.builder()
-                .documentNumber(extractTextContent(doc, "ID"))
+                .documentNumber(extractDocumentId(doc))
                 .buyerReference(extractTextContent(doc, "BuyerReference"))
                 .documentDate(extractIssueDate(doc))
                 .currency(extractTextContent(doc, "InvoiceCurrencyCode"))
                 .paymentTerms(extractPaymentTerms(doc))
                 .delivery(extractDeliveryInformation(doc))
                 .build();
+    }
+
+    private String extractDocumentId(Document doc) {
+        NodeList exchangedDocs = doc.getElementsByTagNameNS("*", "ExchangedDocument");
+        if (exchangedDocs.getLength() > 0) {
+            Element exchangedDoc = (Element) exchangedDocs.item(0);
+            NodeList idNodes = exchangedDoc.getElementsByTagNameNS("*", "ID");
+            if (idNodes.getLength() > 0) {
+                return idNodes.item(0).getTextContent().trim();
+            }
+        }
+        return null;
     }
 
     private LocalDate extractIssueDate(Document doc) {


### PR DESCRIPTION
## Summary
- add InvoiceReader.extractDocumentId to target `rsm:ExchangedDocument/ram:ID`
- populate messageId and documentNumber using the dedicated extractor

## Testing
- `mvn -q test` *(fails: Plugin org.codehaus.mojo:jaxb2-maven-plugin:3.3.0 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68934474fa3c832ebb81786f3b6e470d