### PR TITLE
Remove unused XmlMapper in service layer

### DIFF
--- a/cii-messaging-parent/cii-service/pom.xml
+++ b/cii-messaging-parent/cii-service/pom.xml
@@ -43,10 +43,6 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-xml</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>

--- a/cii-messaging-parent/cii-service/src/main/java/com/cii/messaging/service/impl/CIIMessagingServiceImpl.java
+++ b/cii-messaging-parent/cii-service/src/main/java/com/cii/messaging/service/impl/CIIMessagingServiceImpl.java
@@ -7,7 +7,6 @@ import com.cii.messaging.validator.*;
 import com.cii.messaging.validator.impl.CompositeValidator;
 import com.cii.messaging.service.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,14 +25,11 @@ public class CIIMessagingServiceImpl implements CIIMessagingService {
     private static final Logger logger = LoggerFactory.getLogger(CIIMessagingServiceImpl.class);
     
     private final ObjectMapper jsonMapper;
-    private final XmlMapper xmlMapper;
     private final CIIValidator validator;
     
     public CIIMessagingServiceImpl() {
         this.jsonMapper = new ObjectMapper();
         this.jsonMapper.findAndRegisterModules(); // For Java 8 time support
-        this.xmlMapper = new XmlMapper();
-        this.xmlMapper.findAndRegisterModules();
         this.validator = new CompositeValidator();
     }
     

--- a/cii-messaging-parent/cii-service/src/test/java/com/cii/messaging/service/impl/CIIMessagingServiceImplTest.java
+++ b/cii-messaging-parent/cii-service/src/test/java/com/cii/messaging/service/impl/CIIMessagingServiceImplTest.java
@@ -1,0 +1,29 @@
+package com.cii.messaging.service.impl;
+
+import com.cii.messaging.model.CIIMessage;
+import com.cii.messaging.model.MessageType;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CIIMessagingServiceImplTest {
+
+    @Test
+    void testJsonConversionRoundTrip() throws Exception {
+        CIIMessagingServiceImpl service = new CIIMessagingServiceImpl();
+
+        CIIMessage original = CIIMessage.builder()
+                .messageId("123")
+                .messageType(MessageType.ORDER)
+                .creationDateTime(LocalDateTime.now())
+                .build();
+
+        String json = service.convertToJson(original);
+        CIIMessage result = service.convertFromJson(json, MessageType.ORDER);
+
+        assertEquals(original.getMessageId(), result.getMessageId());
+        assertEquals(original.getMessageType(), result.getMessageType());
+    }
+}


### PR DESCRIPTION
## Summary
- drop unused `XmlMapper` field and its Jackson dependency
- add unit test covering JSON round-trip for `CIIMessagingServiceImpl`

## Testing
- `mvn -q -pl cii-service -am test` *(fails: Plugin org.codehaus.mojo:jaxb2-maven-plugin:3.3.0 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68936463403c832e81b40fd7a11c9bc7