### PR TITLE
feat: harden XML reader against XXE

### DIFF
--- a/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/CIIReaderFactory.java
+++ b/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/CIIReaderFactory.java
@@ -30,7 +30,8 @@ public class CIIReaderFactory {
     public static CIIReader createReader(String xmlContent) throws CIIReaderException {
         XMLInputFactory factory = XMLInputFactory.newFactory();
         factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
-        factory.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
+        factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+        factory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false);
 
         XMLStreamReader reader = null;
         try {

--- a/cii-messaging-parent/cii-reader/src/test/java/com/cii/messaging/reader/XXEReaderTest.java
+++ b/cii-messaging-parent/cii-reader/src/test/java/com/cii/messaging/reader/XXEReaderTest.java
@@ -7,6 +7,7 @@ import com.cii.messaging.reader.impl.OrderReader;
 import com.cii.messaging.reader.impl.OrderResponseReader;
 import org.junit.jupiter.api.Test;
 import org.xml.sax.SAXParseException;
+import javax.xml.stream.XMLStreamException;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -68,5 +69,11 @@ public class XXEReaderTest {
         File file = createTempXml();
         CIIReaderException ex = assertThrows(CIIReaderException.class, () -> reader.read(file));
         assertTrue(ex.getCause() instanceof SAXParseException);
+    }
+
+    @Test
+    void factoryRejectsExternalEntities() {
+        CIIReaderException ex = assertThrows(CIIReaderException.class, () -> CIIReaderFactory.createReader(XXE));
+        assertTrue(ex.getCause() instanceof XMLStreamException);
     }
 }


### PR DESCRIPTION
## Summary
- replace string-based external entity property with constants and disable entity reference replacement
- extend XXE tests to cover CIIReaderFactory parsing

## Testing
- `mvn -q -pl cii-reader -am test` *(fails: Could not transfer artifact maven-resources-plugin:pom:3.3.1: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68936464433c832e883de3a9e178e3fd