### PR TITLE
Add output format enum and robust CLI file handling

### DIFF
--- a/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/GenerateCommand.java
+++ b/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/GenerateCommand.java
@@ -5,7 +5,10 @@ import com.cii.messaging.service.CIIMessagingService;
 import com.cii.messaging.service.impl.CIIMessagingServiceImpl;
 import picocli.CommandLine.*;
 import java.io.File;
+import java.io.IOException;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -33,7 +36,7 @@ public class GenerateCommand implements Callable<Integer> {
     private String receiverPartyId;
     
     @Option(names = {"--format"}, description = "Output format: XML or JSON", defaultValue = "XML")
-    private String format;
+    private OutputFormat format;
     
     private final CIIMessagingService service = new CIIMessagingServiceImpl();
     
@@ -42,11 +45,15 @@ public class GenerateCommand implements Callable<Integer> {
         System.out.println("Generating " + messageType + " message...");
         
         CIIMessage message;
-        
-        if (orderFile != null && orderFile.exists()) {
+
+        if (orderFile != null) {
+            if (!orderFile.exists() || !orderFile.isFile() || !orderFile.canRead()) {
+                System.err.println("Order file must be a readable file: " + orderFile);
+                return 1;
+            }
             // Generate from existing ORDER
             CIIMessage order = service.readMessage(orderFile);
-            
+
             switch (messageType) {
                 case INVOICE:
                     message = service.createInvoiceResponse(order);
@@ -55,7 +62,7 @@ public class GenerateCommand implements Callable<Integer> {
                     message = service.createDespatchAdvice(order);
                     break;
                 case ORDERSP:
-                    message = service.createOrderResponse(order, 
+                    message = service.createOrderResponse(order,
                         com.cii.messaging.service.OrderResponseType.ACCEPTED);
                     break;
                 default:
@@ -66,22 +73,34 @@ public class GenerateCommand implements Callable<Integer> {
             // Generate sample message
             message = createSampleMessage();
         }
-        
+
         // Ensure output directory exists
-        java.io.File parent = outputFile.getParentFile();
+        File parent = outputFile.getParentFile();
         if (parent != null) {
-            parent.mkdirs();
+            if (parent.exists()) {
+                if (!parent.isDirectory()) {
+                    System.err.println("Output parent is not a directory: " + parent);
+                    return 1;
+                }
+            } else if (!parent.mkdirs()) {
+                System.err.println("Failed to create directories for output file: " + parent);
+                return 1;
+            }
         }
 
         // Write output
-        if ("JSON".equalsIgnoreCase(format)) {
-            String json = service.convertToJson(message);
-            java.nio.file.Files.writeString(outputFile.toPath(), json,
-                    java.nio.charset.StandardCharsets.UTF_8);
-        } else {
-            service.writeMessage(message, outputFile);
+        try {
+            if (format == OutputFormat.JSON) {
+                String json = service.convertToJson(message);
+                Files.writeString(outputFile.toPath(), json, StandardCharsets.UTF_8);
+            } else {
+                service.writeMessage(message, outputFile);
+            }
+        } catch (IOException e) {
+            System.err.println("Failed to write output file: " + e.getMessage());
+            return 1;
         }
-        
+
         System.out.println("Generated " + messageType + " saved to: " + outputFile.getAbsolutePath());
         return 0;
     }

--- a/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/OutputFormat.java
+++ b/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/OutputFormat.java
@@ -1,0 +1,6 @@
+package com.cii.messaging.cli;
+
+public enum OutputFormat {
+    XML,
+    JSON
+}

--- a/cii-messaging-parent/cii-cli/src/test/java/com/cii/messaging/cli/GenerateCommandTest.java
+++ b/cii-messaging-parent/cii-cli/src/test/java/com/cii/messaging/cli/GenerateCommandTest.java
@@ -1,0 +1,60 @@
+package com.cii.messaging.cli;
+
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GenerateCommandTest {
+
+    @Test
+    void failsWhenOrderFileIsNotReadableFile() throws IOException {
+        Path tempDir = Files.createTempDirectory("orderDir");
+        Path output = Files.createTempFile("out", ".xml");
+        CommandLine cmd = new CommandLine(new GenerateCommand());
+        StringWriter err = new StringWriter();
+        cmd.setErr(new PrintWriter(err));
+        int exit = cmd.execute("INVOICE", "-o", output.toString(), "--from-order", tempDir.toString());
+        assertEquals(1, exit);
+        assertTrue(err.toString().contains("readable"));
+    }
+
+    @Test
+    void failsWhenCannotCreateOutputDirectories() throws IOException {
+        Path root = Files.createTempDirectory("root");
+        Path file = Files.createTempFile(root, "file", ".txt");
+        Path output = file.resolve("subdir/out.xml");
+        CommandLine cmd = new CommandLine(new GenerateCommand());
+        StringWriter err = new StringWriter();
+        cmd.setErr(new PrintWriter(err));
+        int exit = cmd.execute("INVOICE", "-o", output.toString());
+        assertEquals(1, exit);
+        assertTrue(err.toString().contains("Failed to create directories"));
+    }
+
+    @Test
+    void failsWhenWritingToDirectory() throws IOException {
+        Path dir = Files.createTempDirectory("outdir");
+        CommandLine cmd = new CommandLine(new GenerateCommand());
+        StringWriter err = new StringWriter();
+        cmd.setErr(new PrintWriter(err));
+        int exit = cmd.execute("INVOICE", "-o", dir.toString());
+        assertEquals(1, exit);
+        assertTrue(err.toString().contains("Failed to write output"));
+    }
+
+    @Test
+    void generatesJsonOutput() throws IOException {
+        Path output = Files.createTempFile("message", ".json");
+        CommandLine cmd = new CommandLine(new GenerateCommand());
+        int exit = cmd.execute("INVOICE", "-o", output.toString(), "--format", "JSON");
+        assertEquals(0, exit);
+        assertTrue(Files.size(output) > 0);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `OutputFormat` enum to select JSON or XML generation
- validate order files and output directories before generating messages
- add CLI tests for file validation, directory creation failures, write failures and JSON generation

## Testing
- `mvn -q -pl cii-cli test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6893646671c4832e9525ff73d6e7823a