### PR TITLE
Refactor parse command format and add validation tests

### DIFF
--- a/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/OutputFormat.java
+++ b/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/OutputFormat.java
@@ -1,0 +1,6 @@
+package com.cii.messaging.cli;
+
+public enum OutputFormat {
+    SUMMARY,
+    JSON
+}

--- a/cii-messaging-parent/cii-cli/src/test/java/com/cii/messaging/cli/ParseCommandTest.java
+++ b/cii-messaging-parent/cii-cli/src/test/java/com/cii/messaging/cli/ParseCommandTest.java
@@ -1,0 +1,37 @@
+package com.cii.messaging.cli;
+
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+import java.io.File;
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ParseCommandTest {
+
+    @Test
+    void testInvalidFormat() {
+        CommandLine cmd = new CommandLine(new ParseCommand());
+        int exitCode = cmd.execute("--format", "XML", "dummy.xml");
+        assertNotEquals(0, exitCode);
+    }
+
+    @Test
+    void testUnreadableFile() throws Exception {
+        ParseCommand command = new ParseCommand();
+        Field inputField = ParseCommand.class.getDeclaredField("inputFile");
+        inputField.setAccessible(true);
+        File fake = new File("dummy") {
+            @Override
+            public boolean exists() { return true; }
+            @Override
+            public boolean isFile() { return true; }
+            @Override
+            public boolean canRead() { return false; }
+        };
+        inputField.set(command, fake);
+        Integer result = command.call();
+        assertEquals(1, result.intValue());
+    }
+}


### PR DESCRIPTION
## Summary
- Replace string format option with `OutputFormat` enum
- Validate input file type and readability before parsing
- Handle file write errors and add CLI edge-case tests

## Testing
- `mvn -q -pl cii-cli -am test` *(fails: Could not transfer artifact org.codehaus.mojo:jaxb2-maven-plugin:pom:3.3.0 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68936467a7a0832e911af757a3e791ae