### PR TITLE
feat(cli): robust format detection

### DIFF
--- a/cii-messaging-parent/README.md
+++ b/cii-messaging-parent/README.md
@@ -142,6 +142,9 @@ java -jar cii-cli.jar convert invoice.json \
   --output invoice.xml
 ```
 
+> ⚠️ La conversion échoue si le fichier d'entrée est déjà dans le format cible ou
+> si son contenu n'est pas un JSON ou XML valide.
+
 ## 🔌 Utilisation programmatique
 
 ### Exemple simple

--- a/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/ConvertCommand.java
+++ b/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/ConvertCommand.java
@@ -4,11 +4,16 @@ import com.cii.messaging.model.CIIMessage;
 import com.cii.messaging.model.MessageType;
 import com.cii.messaging.service.CIIMessagingService;
 import com.cii.messaging.service.impl.CIIMessagingServiceImpl;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import picocli.CommandLine.*;
 import java.io.File;
+import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.concurrent.Callable;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.xml.sax.InputSource;
 
 @Command(
     name = "convert",
@@ -21,48 +26,101 @@ public class ConvertCommand implements Callable<Integer> {
     
     @Option(names = {"-o", "--output"}, description = "Output file", required = true)
     private File outputFile;
-    
+
     @Option(names = {"-t", "--to"}, description = "Target format: XML or JSON", required = true)
-    private String targetFormat;
+    private TargetFormat targetFormat;
     
     @Option(names = {"--type"}, description = "Message type (required for JSON to XML)")
     private MessageType messageType;
     
     private final CIIMessagingService service = new CIIMessagingServiceImpl();
+
+    /**
+     * Supported output formats for conversion.
+     */
+    enum TargetFormat {
+        XML, JSON
+    }
     
+    /**
+     * Executes the conversion.
+     *
+     * @return 0 on success, 1 on error
+     * @throws Exception if unexpected errors occur
+     */
     @Override
     public Integer call() throws Exception {
         if (!inputFile.exists()) {
             System.err.println("Input file not found: " + inputFile);
             return 1;
         }
-        
+        if (!inputFile.isFile()) {
+            System.err.println("Input is not a file: " + inputFile);
+            return 1;
+        }
+        if (!inputFile.canRead()) {
+            System.err.println("Cannot read input file: " + inputFile);
+            return 1;
+        }
+
         System.out.println("Converting " + inputFile.getName() + " to " + targetFormat + "...");
-        
+
         try {
             String inputContent = Files.readString(inputFile.toPath(), StandardCharsets.UTF_8);
-            boolean isInputJson = inputContent.trim().startsWith("{");
+            boolean isJson = false;
+            boolean isXml = false;
+            Exception jsonError = null;
+            Exception xmlError = null;
+
+            try {
+                new ObjectMapper().readTree(inputContent);
+                isJson = true;
+            } catch (JsonProcessingException e) {
+                jsonError = e;
+            }
+
+            if (!isJson) {
+                try {
+                    DocumentBuilderFactory.newInstance()
+                            .newDocumentBuilder()
+                            .parse(new InputSource(new StringReader(inputContent)));
+                    isXml = true;
+                } catch (Exception e) {
+                    xmlError = e;
+                }
+            }
+
+            if (isJson && targetFormat == TargetFormat.JSON) {
+                System.err.println("Input is already JSON");
+                return 1;
+            }
+            if (isXml && targetFormat == TargetFormat.XML) {
+                System.err.println("Input is already XML");
+                return 1;
+            }
+            if (!isJson && !isXml) {
+                System.err.println("Input is neither valid JSON nor XML");
+                if (jsonError != null) {
+                    System.err.println("JSON parse error: " + jsonError.getMessage());
+                }
+                if (xmlError != null) {
+                    System.err.println("XML parse error: " + xmlError.getMessage());
+                }
+                return 1;
+            }
 
             java.io.File parent = outputFile.getParentFile();
             if (parent != null) {
                 parent.mkdirs();
             }
-            
-            if ("JSON".equalsIgnoreCase(targetFormat)) {
-                if (isInputJson) {
-                    System.err.println("Input is already JSON");
-                    return 1;
-                }
+
+            if (targetFormat == TargetFormat.JSON) {
                 // XML to JSON
                 CIIMessage message = service.readMessage(inputFile);
                 String json = service.convertToJson(message);
                 Files.writeString(outputFile.toPath(), json, StandardCharsets.UTF_8);
-                
-            } else if ("XML".equalsIgnoreCase(targetFormat)) {
-                if (!isInputJson) {
-                    System.err.println("Input is already XML");
-                    return 1;
-                }
+
+            } else if (targetFormat == TargetFormat.XML) {
                 // JSON to XML
                 if (messageType == null) {
                     System.err.println("Message type required for JSON to XML conversion (use --type)");
@@ -70,15 +128,11 @@ public class ConvertCommand implements Callable<Integer> {
                 }
                 CIIMessage message = service.convertFromJson(inputContent, messageType);
                 service.writeMessage(message, outputFile);
-                
-            } else {
-                System.err.println("Invalid target format: " + targetFormat);
-                return 1;
             }
-            
+
             System.out.println("Conversion successful! Output saved to: " + outputFile.getAbsolutePath());
             return 0;
-            
+
         } catch (Exception e) {
             System.err.println("Conversion failed: " + e.getMessage());
             if (e.getCause() != null) {

--- a/cii-messaging-parent/cii-cli/src/test/java/com/cii/messaging/cli/ConvertCommandTest.java
+++ b/cii-messaging-parent/cii-cli/src/test/java/com/cii/messaging/cli/ConvertCommandTest.java
@@ -1,0 +1,76 @@
+package com.cii.messaging.cli;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import picocli.CommandLine;
+
+public class ConvertCommandTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void failsWhenInputAlreadyJson() throws Exception {
+        Path input = tempDir.resolve("input.json");
+        Files.writeString(input, "{}");
+        Path output = tempDir.resolve("out.json");
+
+        PrintStream originalErr = System.err;
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(err));
+        try {
+            int exitCode = new CommandLine(new ConvertCommand())
+                    .execute(input.toString(), "-o", output.toString(), "-t", "JSON");
+            assertEquals(1, exitCode);
+            assertTrue(err.toString().contains("Input is already JSON"));
+        } finally {
+            System.setErr(originalErr);
+        }
+    }
+
+    @Test
+    void failsWhenInputAlreadyXml() throws Exception {
+        Path input = tempDir.resolve("input.xml");
+        Files.writeString(input, "<root/>");
+        Path output = tempDir.resolve("out.xml");
+
+        PrintStream originalErr = System.err;
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(err));
+        try {
+            int exitCode = new CommandLine(new ConvertCommand())
+                    .execute(input.toString(), "-o", output.toString(), "-t", "XML");
+            assertEquals(1, exitCode);
+            assertTrue(err.toString().contains("Input is already XML"));
+        } finally {
+            System.setErr(originalErr);
+        }
+    }
+
+    @Test
+    void failsWhenInputMalformed() throws Exception {
+        Path input = tempDir.resolve("input.txt");
+        Files.writeString(input, "not json or xml");
+        Path output = tempDir.resolve("out.json");
+
+        PrintStream originalErr = System.err;
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(err));
+        try {
+            int exitCode = new CommandLine(new ConvertCommand())
+                    .execute(input.toString(), "-o", output.toString(), "-t", "JSON");
+            assertEquals(1, exitCode);
+            assertTrue(err.toString().contains("neither valid JSON nor XML"));
+        } finally {
+            System.setErr(originalErr);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- use TargetFormat enum to select conversion output
- parse input to detect JSON/XML with error details and file checks
- document and test malformed or already-converted inputs

## Testing
- `mvn -q -pl cii-cli -am test` *(fails: Could not transfer artifact org.codehaus.mojo:jaxb2-maven-plugin:pom:3.3.0 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689364688020832e867e325eed097e7d