### PR TITLE
feat(cli): improve schema option and file validation

### DIFF
--- a/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/ValidateCommand.java
+++ b/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/ValidateCommand.java
@@ -6,8 +6,6 @@ import com.cii.messaging.validator.*;
 import picocli.CommandLine.*;
 import java.io.File;
 import java.util.concurrent.Callable;
-import java.util.List;
-import java.util.Arrays;
 
 @Command(
     name = "validate",
@@ -19,7 +17,7 @@ public class ValidateCommand implements Callable<Integer> {
     private File[] inputFiles;
     
     @Option(names = {"--schema"}, description = "Schema version: D16B, D20B, D21B", defaultValue = "D16B")
-    private String schemaVersion;
+    private SchemaVersion schemaVersion;
     
     @Option(names = {"-v", "--verbose"}, description = "Show detailed validation results")
     private boolean verbose;
@@ -31,25 +29,27 @@ public class ValidateCommand implements Callable<Integer> {
         int totalFiles = inputFiles.length;
         int validFiles = 0;
         
-        SchemaVersion version;
-        try {
-            version = SchemaVersion.valueOf(schemaVersion.toUpperCase());
-        } catch (IllegalArgumentException e) {
-            System.err.println("Invalid schema version: " + schemaVersion + ". Allowed values: " + Arrays.toString(SchemaVersion.values()));
-            return 1;
-        }
-        System.out.println("Validating " + totalFiles + " file(s) against " + version.getVersion() + "...\n");
+        System.out.println("Validating " + totalFiles + " file(s) against " + schemaVersion.getVersion() + "...\n");
+
+        service.setSchemaVersion(schemaVersion);
 
         for (File file : inputFiles) {
             if (!file.exists()) {
                 System.err.println("File not found: " + file);
                 continue;
             }
+            if (!file.isFile()) {
+                System.err.println("Not a file: " + file);
+                continue;
+            }
+            if (!file.canRead()) {
+                System.err.println("Cannot read file: " + file);
+                continue;
+            }
 
             System.out.println("Validating: " + file.getName());
 
             try {
-                service.setSchemaVersion(version);
                 ValidationResult result = service.validateMessage(file);
                 
                 if (result.isValid()) {

--- a/cii-messaging-parent/cii-cli/src/test/java/com/cii/messaging/cli/ValidateCommandTest.java
+++ b/cii-messaging-parent/cii-cli/src/test/java/com/cii/messaging/cli/ValidateCommandTest.java
@@ -1,0 +1,70 @@
+package com.cii.messaging.cli;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+class ValidateCommandTest {
+
+    @Test
+    void directoryIsRejected(@TempDir Path tempDir) {
+        ValidateCommand cmd = new ValidateCommand();
+        CommandLine cli = new CommandLine(cmd);
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        cli.setErr(new PrintWriter(err, true));
+
+        int exitCode = cli.execute(tempDir.toString());
+
+        assertThat(exitCode).isEqualTo(1);
+        assertThat(err.toString()).contains("Not a file: " + tempDir.toFile());
+    }
+
+    @Test
+    void unreadableFileIsRejected(@TempDir Path tempDir) throws Exception {
+        Path file = tempDir.resolve("test.xml");
+        Files.writeString(file, "<xml/>");
+
+        try {
+            Files.setPosixFilePermissions(file, Set.of());
+        } catch (UnsupportedOperationException e) {
+            // skip test on filesystems that do not support POSIX permissions
+            assumeTrue(false);
+        }
+        assumeTrue(!Files.isReadable(file));
+
+        ValidateCommand cmd = new ValidateCommand();
+        CommandLine cli = new CommandLine(cmd);
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        cli.setErr(new PrintWriter(err, true));
+
+        int exitCode = cli.execute(file.toString());
+
+        assertThat(exitCode).isEqualTo(1);
+        assertThat(err.toString()).contains("Cannot read file: " + file.toFile());
+    }
+
+    @Test
+    void invalidSchemaVersionIsReported(@TempDir Path tempDir) throws Exception {
+        Path file = tempDir.resolve("valid.xml");
+        Files.writeString(file, "<xml/>");
+
+        ValidateCommand cmd = new ValidateCommand();
+        CommandLine cli = new CommandLine(cmd);
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        cli.setErr(new PrintWriter(err, true));
+
+        int exitCode = cli.execute("--schema", "foo", file.toString());
+
+        assertThat(exitCode).isNotEqualTo(0);
+        assertThat(err.toString()).contains("Invalid value for option '--schema'");
+    }
+}


### PR DESCRIPTION
## Summary
- parse schema version enum directly via picocli
- set schema version once before validating files
- add safety checks for non-file or unreadable inputs and tests

## Testing
- `mvn -q -pl cii-cli test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6893646b496c832ebb6f125bececd74f