### PR TITLE
Handle SAXParseException from factory XXE tests

### DIFF
--- a/cii-messaging-parent/cii-reader/src/test/java/com/cii/messaging/reader/XXEReaderTest.java
+++ b/cii-messaging-parent/cii-reader/src/test/java/com/cii/messaging/reader/XXEReaderTest.java
@@ -74,6 +74,8 @@ public class XXEReaderTest {
     @Test
     void factoryRejectsExternalEntities() {
         CIIReaderException ex = assertThrows(CIIReaderException.class, () -> CIIReaderFactory.createReader(XXE));
-        assertTrue(ex.getCause() instanceof XMLStreamException);
+        Throwable cause = ex.getCause();
+        assertTrue(cause instanceof SAXParseException || cause instanceof XMLStreamException,
+                "Unexpected cause type: " + (cause == null ? "null" : cause.getClass().getName()));
     }
 }


### PR DESCRIPTION
## Summary
- Accept SAXParseException or XMLStreamException as the cause when factory parses XML with external entities.

## Testing
- `mvn -q -pl cii-reader -am test` *(fails: Plugin org.codehaus.mojo:jaxb2-maven-plugin:3.3.0 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68937449ae28832eadbaa5dbe092dc7d