### PR TITLE
Add validation time tracking to CompositeValidator

### DIFF
--- a/cii-messaging-parent/cii-validator/src/main/java/com/cii/messaging/validator/impl/CompositeValidator.java
+++ b/cii-messaging-parent/cii-validator/src/main/java/com/cii/messaging/validator/impl/CompositeValidator.java
@@ -30,6 +30,8 @@ public class CompositeValidator implements CIIValidator {
     
     @Override
     public ValidationResult validate(File xmlFile) {
+        long start = System.currentTimeMillis();
+
         ValidationResult.ValidationResultBuilder combinedResult = ValidationResult.builder();
         combinedResult.valid(true);
         
@@ -56,7 +58,8 @@ public class CompositeValidator implements CIIValidator {
         combinedResult.errors(allErrors);
         combinedResult.warnings(allWarnings);
         combinedResult.validatedAgainst(validatedAgainst.toString());
-        
+        combinedResult.validationTimeMs(System.currentTimeMillis() - start);
+
         return combinedResult.build();
     }
     
@@ -112,6 +115,8 @@ public class CompositeValidator implements CIIValidator {
     }
 
     private ValidationResult validateBuffered(byte[] data) {
+        long start = System.currentTimeMillis();
+
         ValidationResult.ValidationResultBuilder combinedResult = ValidationResult.builder();
         combinedResult.valid(true);
 
@@ -138,6 +143,7 @@ public class CompositeValidator implements CIIValidator {
         combinedResult.errors(allErrors);
         combinedResult.warnings(allWarnings);
         combinedResult.validatedAgainst(validatedAgainst.toString());
+        combinedResult.validationTimeMs(System.currentTimeMillis() - start);
 
         return combinedResult.build();
     }

--- a/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/validator/impl/CompositeValidatorTest.java
+++ b/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/validator/impl/CompositeValidatorTest.java
@@ -23,6 +23,14 @@ class CompositeValidatorTest {
             this.result = result;
         }
 
+        private void pause() {
+            try {
+                Thread.sleep(1);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
         @Override
         public ValidationResult validate(File xmlFile) {
             try (InputStream is = new FileInputStream(xmlFile)) {
@@ -39,18 +47,21 @@ class CompositeValidatorTest {
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
+            pause();
             return result;
         }
 
         @Override
         public ValidationResult validate(String xmlContent) {
             lastInput = xmlContent;
+            pause();
             return result;
         }
 
         @Override
         public ValidationResult validate(CIIMessage message) {
             lastInput = "message";
+            pause();
             return result;
         }
 
@@ -106,20 +117,32 @@ class CompositeValidatorTest {
         File temp = Files.createTempFile("cii", ".xml").toFile();
         Files.writeString(temp.toPath(), xml, StandardCharsets.UTF_8);
         ValidationResult fileResult = composite.validate(temp);
-        assertEquals(expected, fileResult);
+        assertEquals(expected.isValid(), fileResult.isValid());
+        assertEquals(expected.getErrors(), fileResult.getErrors());
+        assertEquals(expected.getWarnings(), fileResult.getWarnings());
+        assertEquals(expected.getValidatedAgainst(), fileResult.getValidatedAgainst());
+        assertTrue(fileResult.getValidationTimeMs() > 0);
         assertEquals(xml, v1.lastInput);
         assertEquals(xml, v2.lastInput);
 
         // InputStream
         ValidationResult streamResult = composite.validate(
                 new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
-        assertEquals(expected, streamResult);
+        assertEquals(expected.isValid(), streamResult.isValid());
+        assertEquals(expected.getErrors(), streamResult.getErrors());
+        assertEquals(expected.getWarnings(), streamResult.getWarnings());
+        assertEquals(expected.getValidatedAgainst(), streamResult.getValidatedAgainst());
+        assertTrue(streamResult.getValidationTimeMs() > 0);
         assertEquals(xml, v1.lastInput);
         assertEquals(xml, v2.lastInput);
 
         // String
         ValidationResult stringResult = composite.validate(xml);
-        assertEquals(expected, stringResult);
+        assertEquals(expected.isValid(), stringResult.isValid());
+        assertEquals(expected.getErrors(), stringResult.getErrors());
+        assertEquals(expected.getWarnings(), stringResult.getWarnings());
+        assertEquals(expected.getValidatedAgainst(), stringResult.getValidatedAgainst());
+        assertTrue(stringResult.getValidationTimeMs() > 0);
         assertEquals(xml, v1.lastInput);
         assertEquals(xml, v2.lastInput);
 
@@ -133,7 +156,11 @@ class CompositeValidatorTest {
                 .build();
 
         ValidationResult msgResult = composite.validate(msg);
-        assertEquals(expected, msgResult);
+        assertEquals(expected.isValid(), msgResult.isValid());
+        assertEquals(expected.getErrors(), msgResult.getErrors());
+        assertEquals(expected.getWarnings(), msgResult.getWarnings());
+        assertEquals(expected.getValidatedAgainst(), msgResult.getValidatedAgainst());
+        assertTrue(msgResult.getValidationTimeMs() > 0);
         assertEquals(v1.lastInput, v2.lastInput);
         assertNotNull(v1.lastInput);
     }


### PR DESCRIPTION
## Summary
- measure total validation duration in `CompositeValidator` for file and buffered inputs
- assert validation time is recorded in `CompositeValidatorTest`

## Testing
- `mvn -q -pl cii-validator -am test` *(fails: Plugin org.codehaus.mojo:jaxb2-maven-plugin:3.3.0 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68938d18a5fc832eaea317faed1a7c01