### PR TITLE
feat: support ORDERSP writing

### DIFF
--- a/cii-messaging-parent/README.md
+++ b/cii-messaging-parent/README.md
@@ -152,6 +152,43 @@ service.writeMessage(desadv, new File("desadv.xml"));
 // Génération d'une réponse à commande
 CIIMessage ordersp = service.createOrderResponse(order, OrderResponseType.ACCEPTED);
 service.writeMessage(ordersp, new File("ordersp.xml"));
+
+// Génération directe d'un message INVOICE manuel
+CIIMessage invoice = CIIMessage.builder()
+    .messageId("INV-2024-001")
+    .messageType(MessageType.INVOICE)
+    .creationDateTime(java.time.LocalDateTime.now())
+    .header(DocumentHeader.builder().documentNumber("INV-2024-001").currency("EUR").build())
+    .lineItems(java.util.List.of(
+        LineItem.builder()
+            .lineNumber("1")
+            .productId("4012345678901")
+            .quantity(java.math.BigDecimal.ONE)
+            .unitCode("EA")
+            .unitPrice(java.math.BigDecimal.valueOf(100))
+            .lineAmount(java.math.BigDecimal.valueOf(100))
+            .build()))
+    .build();
+service.writeMessage(invoice, new File("invoice.xml"));
+
+// Génération directe d'un avis DESADV manuel
+CIIMessage manualDesadv = CIIMessage.builder()
+    .messageId("DES-2024-001")
+    .messageType(MessageType.DESADV)
+    .creationDateTime(java.time.LocalDateTime.now())
+    .lineItems(order.getLineItems())
+    .build();
+service.writeMessage(manualDesadv, new File("manual-desadv.xml"));
+
+// Génération directe d'une réponse à commande ORDERSP manuelle
+CIIMessage manualOrdersp = CIIMessage.builder()
+    .messageId("RSP-2024-001")
+    .messageType(MessageType.ORDERSP)
+    .creationDateTime(java.time.LocalDateTime.now())
+    .header(DocumentHeader.builder().documentNumber("RSP-2024-001").build())
+    .lineItems(order.getLineItems())
+    .build();
+service.writeMessage(manualOrdersp, new File("manual-ordersp.xml"));
 ```
 
 ## 🔍 Validation

--- a/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/impl/OrderResponseWriter.java
+++ b/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/impl/OrderResponseWriter.java
@@ -9,14 +9,44 @@ import org.w3c.dom.Element;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.OutputStream;
 
 public class OrderResponseWriter extends AbstractCIIWriter {
-    
+
+    public OrderResponseWriter() {
+        namespaces.put("rsm", "urn:un:unece:uncefact:data:standard:CrossIndustryOrderResponse:16");
+        namespaces.put("ram", "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:16");
+        namespaces.put("udt", "urn:un:unece:uncefact:data:standard:UnqualifiedDataType:16");
+    }
+
     @Override
     protected void initializeJAXBContext() throws JAXBException {
         // Simple XML generation without specific JAXB context
     }
-    
+
+    @Override
+    public void write(CIIMessage message, OutputStream outputStream) throws CIIWriterException {
+        try {
+            Document document = (Document) createDocument(message);
+            TransformerFactory transformerFactory = TransformerFactory.newInstance();
+            Transformer transformer = transformerFactory.newTransformer();
+            if (formatOutput) {
+                transformer.setOutputProperty(javax.xml.transform.OutputKeys.INDENT, "yes");
+                transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+            }
+            transformer.setOutputProperty(javax.xml.transform.OutputKeys.ENCODING, encoding);
+            DOMSource source = new DOMSource(document);
+            StreamResult result = new StreamResult(outputStream);
+            transformer.transform(source, result);
+        } catch (Exception e) {
+            throw new CIIWriterException("Failed to write order response", e);
+        }
+    }
+
     @Override
     protected Object createDocument(CIIMessage message) throws CIIWriterException {
         try {
@@ -25,28 +55,79 @@ public class OrderResponseWriter extends AbstractCIIWriter {
             DocumentBuilder builder = factory.newDocumentBuilder();
             Document doc = builder.newDocument();
 
-            namespaces.clear();
-            namespaces.put("rsm", "urn:un:unece:uncefact:data:standard:CrossIndustryOrderResponse:16");
-            namespaces.put("ram", "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:16");
-            namespaces.put("udt", "urn:un:unece:uncefact:data:standard:UnqualifiedDataType:16");
-
-            // Create root element
+            // Root element
             Element root = createElement(doc, "rsm:CrossIndustryOrderResponse");
             root.setAttribute("xmlns:rsm", namespaces.get("rsm"));
             root.setAttribute("xmlns:ram", namespaces.get("ram"));
             root.setAttribute("xmlns:udt", namespaces.get("udt"));
             doc.appendChild(root);
 
-            // Add ExchangedDocument
+            DocumentHeader header = message.getHeader() != null ? message.getHeader() : DocumentHeader.builder().build();
+
+            // ExchangedDocument
             Element exchangedDoc = createElement(doc, "rsm:ExchangedDocument");
+            addElement(doc, exchangedDoc, "ram:ID", message.getMessageId());
+            addElement(doc, exchangedDoc, "ram:ReferenceID", header.getDocumentNumber());
             root.appendChild(exchangedDoc);
 
-            addElement(doc, exchangedDoc, "ram:ID", message.getMessageId());
+            // Transaction
+            Element transaction = createElement(doc, "rsm:SupplyChainTradeTransaction");
+            root.appendChild(transaction);
+
+            // Parties
+            Element headerAgreement = createElement(doc, "ram:ApplicableHeaderTradeAgreement");
+            if (message.getSeller() != null) {
+                headerAgreement.appendChild(createTradePartyElement(doc, "ram:SellerTradeParty", message.getSeller()));
+            }
+            if (message.getBuyer() != null) {
+                headerAgreement.appendChild(createTradePartyElement(doc, "ram:BuyerTradeParty", message.getBuyer()));
+            }
+            transaction.appendChild(headerAgreement);
+
+            // Line items
+            if (message.getLineItems() != null) {
+                for (LineItem line : message.getLineItems()) {
+                    transaction.appendChild(createLineItemElement(doc, line));
+                }
+            }
 
             return doc;
-            
+
         } catch (Exception e) {
             throw new CIIWriterException("Failed to create Order Response document", e);
         }
+    }
+
+    private Element createTradePartyElement(Document doc, String tagName, TradeParty party) {
+        Element partyElement = createElement(doc, tagName);
+        addElement(doc, partyElement, "ram:ID", party.getId());
+        addElement(doc, partyElement, "ram:Name", party.getName());
+        return partyElement;
+    }
+
+    private Element createLineItemElement(Document doc, LineItem lineItem) {
+        Element line = createElement(doc, "ram:IncludedSupplyChainTradeLineItem");
+
+        Element lineDoc = createElement(doc, "ram:AssociatedDocumentLineDocument");
+        addElement(doc, lineDoc, "ram:LineID", lineItem.getLineNumber());
+        line.appendChild(lineDoc);
+
+        Element product = createElement(doc, "ram:SpecifiedTradeProduct");
+        addElement(doc, product, "ram:GlobalID", lineItem.getProductId());
+        addElement(doc, product, "ram:Name", lineItem.getDescription());
+        line.appendChild(product);
+
+        Element delivery = createElement(doc, "ram:SpecifiedLineTradeDelivery");
+        Element qty = createElement(doc, "ram:BilledQuantity");
+        if (lineItem.getUnitCode() != null) {
+            qty.setAttribute("unitCode", lineItem.getUnitCode());
+        }
+        if (lineItem.getQuantity() != null) {
+            qty.setTextContent(lineItem.getQuantity().toPlainString());
+        }
+        delivery.appendChild(qty);
+        line.appendChild(delivery);
+
+        return line;
     }
 }

--- a/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/impl/OrderResponseWriterTest.java
+++ b/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/impl/OrderResponseWriterTest.java
@@ -1,0 +1,72 @@
+package com.cii.messaging.writer.impl;
+
+import com.cii.messaging.model.*;
+import org.junit.jupiter.api.Test;
+
+import javax.xml.XMLConstants;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.validation.Validator;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.math.BigDecimal;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class OrderResponseWriterTest {
+
+    private CIIMessage sampleMessage() {
+        LineItem line = LineItem.builder()
+                .lineNumber("1")
+                .productId("4012345678901")
+                .description("Item A")
+                .quantity(BigDecimal.ONE)
+                .unitCode("EA")
+                .build();
+
+        DocumentHeader header = DocumentHeader.builder()
+                .documentNumber("ORD-RSP-2024-001")
+                .build();
+
+        return CIIMessage.builder()
+                .messageId("MSG-ORDERSP")
+                .messageType(MessageType.ORDERSP)
+                .creationDateTime(LocalDateTime.parse("20240201120000", DateTimeFormatter.ofPattern("yyyyMMddHHmmss")))
+                .seller(TradeParty.builder().id("SELLER").name("Seller Corp").build())
+                .buyer(TradeParty.builder().id("BUYER").name("Buyer Corp").build())
+                .header(header)
+                .lineItems(java.util.List.of(line))
+                .build();
+    }
+
+    @Test
+    void generatedXmlShouldContainDataAndValidate() throws Exception {
+        CIIMessage message = sampleMessage();
+        OrderResponseWriter writer = new OrderResponseWriter();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        writer.write(message, out);
+        byte[] xml = out.toByteArray();
+        String xmlString = new String(xml);
+
+        assertTrue(xmlString.contains("ORD-RSP-2024-001"));
+        assertTrue(xmlString.contains("4012345678901"));
+
+        Path xsd = Path.of("..", "cii-validator", "src", "main", "resources", "xsd", "d16b", "CrossIndustryOrderResponse.xsd");
+        SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        Schema schema = factory.newSchema(xsd.toFile());
+        Validator validator = schema.newValidator();
+
+        assertDoesNotThrow(() -> {
+            try {
+                validator.validate(new StreamSource(new ByteArrayInputStream(xml)));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- enable Order Response writer to output headers and line items
- cover ORDERSP generation with new unit test and docs

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_6894b5b575f8832e8568ae443f789f15