### PR TITLE
Exclude xml-apis from Xerces to resolve module conflict

### DIFF
--- a/cii-messaging-parent/pom.xml
+++ b/cii-messaging-parent/pom.xml
@@ -78,11 +78,17 @@
                         </dependency>
 
 			<!-- XML Processing -->
-			<dependency>
-				<groupId>xerces</groupId>
-				<artifactId>xercesImpl</artifactId>
-				<version>${xerces.version}</version>
-			</dependency>
+                        <dependency>
+                                <groupId>xerces</groupId>
+                                <artifactId>xercesImpl</artifactId>
+                                <version>${xerces.version}</version>
+                                <exclusions>
+                                        <exclusion>
+                                                <groupId>xml-apis</groupId>
+                                                <artifactId>xml-apis</artifactId>
+                                        </exclusion>
+                                </exclusions>
+                        </dependency>
 			<dependency>
 				<groupId>net.sf.saxon</groupId>
 				<artifactId>Saxon-HE</artifactId>


### PR DESCRIPTION
## Summary
- exclude `xml-apis` from `xercesImpl` to avoid duplicate `javax.xml.parsers`

## Testing
- `mvn -pl cii-cli dependency:tree`


------
https://chatgpt.com/codex/tasks/task_e_68b96bc36ca0832e92f08306af0fd9f3