### PR TITLE
feat: parameterize UN/CEFACT schema version

### DIFF
--- a/cii-messaging-parent/README.md
+++ b/cii-messaging-parent/README.md
@@ -31,6 +31,35 @@ cd cii-messaging-parent
 mvn clean install
 ```
 
+### Choix de la version UN/CEFACT
+
+Les schémas XSD sont chargés depuis `src/main/resources/xsd/<version>/...`.
+La version est déterminée par le paramètre `unece.version` (par défaut `D23B`).
+
+Exemples :
+
+```bash
+# Utiliser la version par défaut (D23B)
+mvn clean install
+
+# Forcer la version D16B
+mvn -Dunece.version=D16B clean install
+
+# Ou via variable d'environnement
+UNECE_VERSION=D16B mvn clean install
+```
+
+Pour ajouter une nouvelle version (ex. `D24A`), déposez simplement les XSD dans
+`cii-model/src/main/resources/xsd/D24A/uncefact/data/standard/` puis construisez avec
+`-Dunece.version=D24A`.
+Les XSD officiels sont disponibles sur [le site de l'UNECE](https://unece.org/trade/uncefact/xml-schemas).
+
+Exemple de chargement en Java :
+
+```java
+Schema schema = UneceSchemaLoader.loadSchema("CrossIndustryInvoice.xsd");
+```
+
 Le JAR exécutable de la CLI est ensuite disponible dans `cii-cli/target/cii-cli-1.0.0-SNAPSHOT-jar-with-dependencies.jar`.
 Pour ne construire que la CLI :
 

--- a/cii-messaging-parent/cii-model/pom.xml
+++ b/cii-messaging-parent/cii-model/pom.xml
@@ -62,7 +62,7 @@
 	            <goal>xjc</goal>
 	          </goals>
 	          <configuration>
-	            <sources>${basedir}/src/main/resources/xsd</sources>
+                    <sources>${basedir}/src/main/resources/xsd/${unece.version}</sources>
 	            <packageName>com.helger.cii.d16b</packageName>
 			     <xjbSources>
 			      <!-- ici on pointe vers votre fichier bindings.xjb -->

--- a/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/util/UneceSchemaLoader.java
+++ b/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/util/UneceSchemaLoader.java
@@ -1,0 +1,61 @@
+package com.cii.messaging.model.util;
+
+import javax.xml.XMLConstants;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import java.io.InputStream;
+
+/**
+ * Utility to load UN/CEFACT XSD schemas based on the {@code unece.version} parameter.
+ * <p>Version resolution order:</p>
+ * <ol>
+ *   <li>System property {@code unece.version}</li>
+ *   <li>Environment variable {@code UNECE_VERSION}</li>
+ *   <li>Default {@code D23B}</li>
+ * </ol>
+ */
+public final class UneceSchemaLoader {
+    public static final String PROPERTY = "unece.version";
+    public static final String ENV = "UNECE_VERSION";
+    public static final String DEFAULT_VERSION = "D23B";
+
+    private UneceSchemaLoader() {
+    }
+
+    /**
+     * Loads a schema file for the resolved UN/CEFACT version.
+     *
+     * @param schemaFile the schema file name (e.g. "CrossIndustryInvoice.xsd")
+     * @return the loaded {@link Schema}
+     * @throws IllegalArgumentException if the schema cannot be found
+     */
+    public static Schema loadSchema(String schemaFile) {
+        String version = resolveVersion();
+        String resourcePath = String.format("/xsd/%s/uncefact/data/standard/%s", version, schemaFile);
+        InputStream xsd = UneceSchemaLoader.class.getResourceAsStream(resourcePath);
+        if (xsd == null) {
+            throw new IllegalArgumentException("XSD schema not found for version " + version + " at " + resourcePath);
+        }
+        try {
+            SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+            return factory.newSchema(new StreamSource(xsd));
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Unable to load schema from " + resourcePath, e);
+        }
+    }
+
+    /**
+     * Resolves the UNECE version from system properties/environment variables.
+     */
+    public static String resolveVersion() {
+        String version = System.getProperty(PROPERTY);
+        if (version == null || version.isEmpty()) {
+            version = System.getenv(ENV);
+        }
+        if (version == null || version.isEmpty()) {
+            version = DEFAULT_VERSION;
+        }
+        return version;
+    }
+}

--- a/cii-messaging-parent/cii-model/src/main/resources/xsd/D16B/uncefact/data/standard/CrossIndustryInvoice.xsd
+++ b/cii-messaging-parent/cii-model/src/main/resources/xsd/D16B/uncefact/data/standard/CrossIndustryInvoice.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:element name="Invoice">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Buyer" type="xs:string"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/cii-messaging-parent/cii-model/src/main/resources/xsd/D23B/uncefact/data/standard/CrossIndustryInvoice.xsd
+++ b/cii-messaging-parent/cii-model/src/main/resources/xsd/D23B/uncefact/data/standard/CrossIndustryInvoice.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+  <xs:element name="Invoice">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="Seller" type="xs:string"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/cii-messaging-parent/cii-model/src/test/java/com/cii/messaging/model/util/UneceSchemaLoaderTest.java
+++ b/cii-messaging-parent/cii-model/src/test/java/com/cii/messaging/model/util/UneceSchemaLoaderTest.java
@@ -1,0 +1,52 @@
+package com.cii.messaging.model.util;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.SAXException;
+
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Validator;
+import java.io.StringReader;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UneceSchemaLoaderTest {
+
+    @AfterEach
+    void clearProperty() {
+        System.clearProperty(UneceSchemaLoader.PROPERTY);
+    }
+
+    private void validate(String xml) throws Exception {
+        Validator validator = UneceSchemaLoader.loadSchema("CrossIndustryInvoice.xsd").newValidator();
+        validator.validate(new StreamSource(new StringReader(xml)));
+    }
+
+    @Test
+    void defaultVersionIsD23B() throws Exception {
+        String valid = "<Invoice><Seller>ACME</Seller></Invoice>";
+        validate(valid); // should not throw
+    }
+
+    @Test
+    void loadD16BWhenSpecified() throws Exception {
+        System.setProperty(UneceSchemaLoader.PROPERTY, "D16B");
+        String valid = "<Invoice><Buyer>ACME</Buyer></Invoice>";
+        validate(valid);
+    }
+
+    @Test
+    void unknownVersionThrows() {
+        System.setProperty(UneceSchemaLoader.PROPERTY, "D99Z");
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+                UneceSchemaLoader.loadSchema("CrossIndustryInvoice.xsd"));
+        assertTrue(ex.getMessage().contains("D99Z"));
+    }
+
+    @Test
+    void validationFailsForWrongVersion() throws Exception {
+        System.setProperty(UneceSchemaLoader.PROPERTY, "D16B");
+        String invalid = "<Invoice><Seller>ACME</Seller></Invoice>";
+        assertThrows(SAXException.class, () -> validate(invalid));
+    }
+}

--- a/cii-messaging-parent/pom.xml
+++ b/cii-messaging-parent/pom.xml
@@ -15,8 +15,11 @@
 	<properties>
 		<java.version>17</java.version>
 		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+                <maven.compiler.target>17</maven.compiler.target>
+                <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+                <!-- UN/CEFACT schema version (can be overridden via -Dunece.version or env) -->
+                <unece.version>D23B</unece.version>
 
 		<!-- Dependencies versions -->
 		<jakarta.xml.bind.version>4.0.1</jakarta.xml.bind.version>


### PR DESCRIPTION
## Summary
- allow selecting UN/CEFACT XSD version via `unece.version` (system property/env)
- resolve schemas from `/xsd/<version>/uncefact/data/standard/`
- document versioning and add minimal D16B/D23B schemas with tests

## Testing
- `mvn -pl cii-model test`


------
https://chatgpt.com/codex/tasks/task_e_68b994137d48832eb319d0954cd922c4