### PR TITLE
Load UNECE schemas from existing resources

### DIFF
--- a/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/util/UneceSchemaLoader.java
+++ b/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/util/UneceSchemaLoader.java
@@ -1,10 +1,9 @@
 package com.cii.messaging.model.util;
 
 import javax.xml.XMLConstants;
-import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
-import java.io.InputStream;
+import java.net.URL;
 
 /**
  * Utility to load UN/CEFACT XSD schemas based on the {@code unece.version} parameter.
@@ -33,13 +32,13 @@ public final class UneceSchemaLoader {
     public static Schema loadSchema(String schemaFile) {
         String version = resolveVersion();
         String resourcePath = String.format("/xsd/%s/uncefact/data/standard/%s", version, schemaFile);
-        InputStream xsd = UneceSchemaLoader.class.getResourceAsStream(resourcePath);
+        URL xsd = UneceSchemaLoader.class.getResource(resourcePath);
         if (xsd == null) {
             throw new IllegalArgumentException("XSD schema not found for version " + version + " at " + resourcePath);
         }
         try {
             SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-            return factory.newSchema(new StreamSource(xsd));
+            return factory.newSchema(xsd);
         } catch (Exception e) {
             throw new IllegalArgumentException("Unable to load schema from " + resourcePath, e);
         }

--- a/cii-messaging-parent/cii-model/src/test/java/com/cii/messaging/model/util/UneceSchemaLoaderTest.java
+++ b/cii-messaging-parent/cii-model/src/test/java/com/cii/messaging/model/util/UneceSchemaLoaderTest.java
@@ -2,11 +2,6 @@ package com.cii.messaging.model.util;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.xml.sax.SAXException;
-
-import javax.xml.transform.stream.StreamSource;
-import javax.xml.validation.Validator;
-import java.io.StringReader;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -17,36 +12,30 @@ class UneceSchemaLoaderTest {
         System.clearProperty(UneceSchemaLoader.PROPERTY);
     }
 
-    private void validate(String xml) throws Exception {
-        Validator validator = UneceSchemaLoader.loadSchema("CrossIndustryInvoice.xsd").newValidator();
-        validator.validate(new StreamSource(new StringReader(xml)));
+    @Test
+    void defaultVersionIsD23B() {
+        assertDoesNotThrow(() -> UneceSchemaLoader.loadSchema("QualifiedDataType_34p0.xsd"));
     }
 
     @Test
-    void defaultVersionIsD23B() throws Exception {
-        String valid = "<Invoice><Seller>ACME</Seller></Invoice>";
-        validate(valid); // should not throw
-    }
-
-    @Test
-    void loadD16BWhenSpecified() throws Exception {
+    void loadD16BWhenSpecified() {
         System.setProperty(UneceSchemaLoader.PROPERTY, "D16B");
-        String valid = "<Invoice><Buyer>ACME</Buyer></Invoice>";
-        validate(valid);
+        assertDoesNotThrow(() -> UneceSchemaLoader.loadSchema("QualifiedDataType_20p0.xsd"));
     }
 
     @Test
     void unknownVersionThrows() {
         System.setProperty(UneceSchemaLoader.PROPERTY, "D99Z");
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
-                UneceSchemaLoader.loadSchema("CrossIndustryInvoice.xsd"));
+                UneceSchemaLoader.loadSchema("QualifiedDataType_34p0.xsd"));
         assertTrue(ex.getMessage().contains("D99Z"));
     }
 
     @Test
-    void validationFailsForWrongVersion() throws Exception {
+    void loadingWrongVersionThrows() {
         System.setProperty(UneceSchemaLoader.PROPERTY, "D16B");
-        String invalid = "<Invoice><Seller>ACME</Seller></Invoice>";
-        assertThrows(SAXException.class, () -> validate(invalid));
+        assertThrows(IllegalArgumentException.class, () ->
+                UneceSchemaLoader.loadSchema("QualifiedDataType_34p0.xsd"));
     }
 }
+


### PR DESCRIPTION
## Summary
- resolve UNECE schema URLs for resource-based loading
- exercise existing QualifiedDataType schemas in loader tests
- remove temporary CrossIndustryInvoice placeholders

## Testing
- `mvn -pl cii-model -Dtest=UneceSchemaLoaderTest test`
- `mvn -pl cii-model -am -DskipTests install`


------
https://chatgpt.com/codex/tasks/task_e_68b99aa33f6c832ea20f9af9e6dc9bad