### PR TITLE
Handle rounding in validator and parse order totals

### DIFF
--- a/cii-messaging-parent/cii-reader/src/test/java/com/cii/messaging/reader/OrderReaderTest.java
+++ b/cii-messaging-parent/cii-reader/src/test/java/com/cii/messaging/reader/OrderReaderTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.net.URL;
+import java.math.BigDecimal;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -20,5 +21,16 @@ public class OrderReaderTest {
         CIIMessage message = reader.read(file);
         assertNotNull(message.getHeader());
         assertEquals("EUR", message.getHeader().getCurrency());
+    }
+
+    @Test
+    void extractsLineTotalFromHeader() throws Exception {
+        OrderReader reader = new OrderReader();
+        URL resource = getClass().getResource("/order-with-header.xml");
+        assertNotNull(resource);
+        File file = new File(resource.toURI());
+        CIIMessage message = reader.read(file);
+        assertNotNull(message.getTotals());
+        assertEquals(new BigDecimal("25000.00"), message.getTotals().getLineTotalAmount());
     }
 }

--- a/cii-messaging-parent/cii-reader/src/test/resources/order-with-header.xml
+++ b/cii-messaging-parent/cii-reader/src/test/resources/order-with-header.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rsm:CrossIndustryOrder xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryOrder:16"
+                        xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:16"
+                        xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:16">
+    <rsm:ExchangedDocument>
+        <ram:ID>ORD-2024-001</ram:ID>
+        <ram:TypeCode>220</ram:TypeCode>
+        <ram:IssueDateTime>
+            <udt:DateTimeString format="102">20240115133000</udt:DateTimeString>
+        </ram:IssueDateTime>
+    </rsm:ExchangedDocument>
+    <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+            <ram:BuyerReference>BUY-REF-2024-001</ram:BuyerReference>
+            <ram:SellerTradeParty>
+                <ram:ID>DE123456789</ram:ID>
+                <ram:Name>Seller Company GmbH</ram:Name>
+                <ram:PostalTradeAddress>
+                    <ram:PostcodeCode>10115</ram:PostcodeCode>
+                    <ram:LineOne>Hauptstraße 123</ram:LineOne>
+                    <ram:CityName>Berlin</ram:CityName>
+                    <ram:CountryID>DE</ram:CountryID>
+                </ram:PostalTradeAddress>
+            </ram:SellerTradeParty>
+            <ram:BuyerTradeParty>
+                <ram:ID>FR987654321</ram:ID>
+                <ram:Name>Buyer Company SAS</ram:Name>
+                <ram:PostalTradeAddress>
+                    <ram:PostcodeCode>75001</ram:PostcodeCode>
+                    <ram:LineOne>Rue de la Paix 456</ram:LineOne>
+                    <ram:CityName>Paris</ram:CityName>
+                    <ram:CountryID>FR</ram:CountryID>
+                </ram:PostalTradeAddress>
+            </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+        <ram:ApplicableHeaderTradeDelivery>
+            <ram:ShipToTradeParty>
+                <ram:ID>FR987654321</ram:ID>
+                <ram:Name>Buyer Warehouse</ram:Name>
+                <ram:PostalTradeAddress>
+                    <ram:PostcodeCode>69001</ram:PostcodeCode>
+                    <ram:LineOne>Zone Industrielle 789</ram:LineOne>
+                    <ram:CityName>Lyon</ram:CityName>
+                    <ram:CountryID>FR</ram:CountryID>
+                </ram:PostalTradeAddress>
+            </ram:ShipToTradeParty>
+            <ram:RequestedDeliverySupplyChainEvent>
+                <ram:OccurrenceDateTime>
+                    <udt:DateTimeString format="102">20240130</udt:DateTimeString>
+                </ram:OccurrenceDateTime>
+            </ram:RequestedDeliverySupplyChainEvent>
+        </ram:ApplicableHeaderTradeDelivery>
+        <ram:ApplicableHeaderTradeSettlement>
+            <ram:OrderCurrencyCode>EUR</ram:OrderCurrencyCode>
+            <ram:SpecifiedTradeSettlementPaymentTerms>
+                <ram:Description>30 days net</ram:Description>
+            </ram:SpecifiedTradeSettlementPaymentTerms>
+        </ram:ApplicableHeaderTradeSettlement>
+        <ram:IncludedSupplyChainTradeLineItem>
+            <ram:AssociatedDocumentLineDocument>
+                <ram:LineID>1</ram:LineID>
+            </ram:AssociatedDocumentLineDocument>
+            <ram:SpecifiedTradeProduct>
+                <ram:GlobalID schemeID="GTIN">4012345678901</ram:GlobalID>
+                <ram:Name>Industrial Widget Type A</ram:Name>
+            </ram:SpecifiedTradeProduct>
+            <ram:SpecifiedLineTradeAgreement>
+                <ram:NetPriceProductTradePrice>
+                    <ram:ChargeAmount>150.00</ram:ChargeAmount>
+                </ram:NetPriceProductTradePrice>
+            </ram:SpecifiedLineTradeAgreement>
+            <ram:SpecifiedLineTradeDelivery>
+                <ram:RequestedQuantity unitCode="EA">100</ram:RequestedQuantity>
+            </ram:SpecifiedLineTradeDelivery>
+            <ram:SpecifiedLineTradeSettlement>
+                <ram:SpecifiedTradeSettlementLineMonetarySummation>
+                    <ram:LineTotalAmount>15000.00</ram:LineTotalAmount>
+                </ram:SpecifiedTradeSettlementLineMonetarySummation>
+            </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+        <ram:IncludedSupplyChainTradeLineItem>
+            <ram:AssociatedDocumentLineDocument>
+                <ram:LineID>2</ram:LineID>
+            </ram:AssociatedDocumentLineDocument>
+            <ram:SpecifiedTradeProduct>
+                <ram:GlobalID schemeID="GTIN">4012345678902</ram:GlobalID>
+                <ram:Name>Industrial Widget Type B</ram:Name>
+            </ram:SpecifiedTradeProduct>
+            <ram:SpecifiedLineTradeAgreement>
+                <ram:NetPriceProductTradePrice>
+                    <ram:ChargeAmount>200.00</ram:ChargeAmount>
+                </ram:NetPriceProductTradePrice>
+            </ram:SpecifiedLineTradeAgreement>
+            <ram:SpecifiedLineTradeDelivery>
+                <ram:RequestedQuantity unitCode="EA">50</ram:RequestedQuantity>
+            </ram:SpecifiedLineTradeDelivery>
+            <ram:SpecifiedLineTradeSettlement>
+                <ram:SpecifiedTradeSettlementLineMonetarySummation>
+                    <ram:LineTotalAmount>10000.00</ram:LineTotalAmount>
+                </ram:SpecifiedTradeSettlementLineMonetarySummation>
+            </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+        <ram:ApplicableHeaderTradeSettlement>
+            <ram:OrderCurrencyCode>EUR</ram:OrderCurrencyCode>
+            <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+                <ram:LineTotalAmount>25000.00</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        </ram:ApplicableHeaderTradeSettlement>
+    </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryOrder>

--- a/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/validator/impl/BusinessRulesValidatorTest.java
+++ b/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/validator/impl/BusinessRulesValidatorTest.java
@@ -119,4 +119,31 @@ class BusinessRulesValidatorTest {
         assertTrue(result.getErrors().stream().anyMatch(e -> "BR-07".equals(e.getRule())));
         assertTrue(result.getErrors().stream().anyMatch(e -> "BR-08".equals(e.getRule())));
     }
+
+    @Test
+    void validateMessageWithRoundingDifferences() {
+        CIIMessage message = CIIMessage.builder()
+                .header(DocumentHeader.builder()
+                        .documentNumber("INV-2")
+                        .documentDate(LocalDate.now())
+                        .buyerReference("BUY-2")
+                        .build())
+                .lineItems(List.of(LineItem.builder()
+                        .lineNumber("1")
+                        .quantity(new BigDecimal("3"))
+                        .unitPrice(new BigDecimal("6.86"))
+                        .lineAmount(new BigDecimal("20.580000000000002"))
+                        .build()))
+                .totals(TotalsInformation.builder()
+                        .lineTotalAmount(new BigDecimal("20.58"))
+                        .grandTotalAmount(new BigDecimal("20.58"))
+                        .duePayableAmount(new BigDecimal("20.58"))
+                        .build())
+                .build();
+
+        BusinessRulesValidator validator = new BusinessRulesValidator();
+        ValidationResult result = validator.validate(message);
+        assertTrue(result.isValid());
+        assertTrue(result.getErrors().isEmpty());
+    }
 }


### PR DESCRIPTION
## Summary
- round line amounts and totals before comparison in BusinessRulesValidator
- read header LineTotalAmount in OrderReader and avoid double counting
- add tests for rounding differences and header totals

## Testing
- `mvn test`
- `java -jar cii-cli/target/cii-cli-1.0.0-SNAPSHOT-jar-with-dependencies.jar validate cii-samples/src/main/resources/samples/AMAZON_OUT.xml`

------
https://chatgpt.com/codex/tasks/task_e_68b9edc44808832e9ec70cf0f6c28866