### PR TITLE
Align model date fields with UNECE XSD

### DIFF
--- a/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/CIIMessage.java
+++ b/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/CIIMessage.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.extern.jackson.Jacksonized;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 @Data
@@ -16,7 +16,7 @@ import java.util.List;
 public class CIIMessage {
     private String messageId;
     private MessageType messageType;
-    private LocalDateTime creationDateTime;
+    private OffsetDateTime creationDateTime;
     private String senderPartyId;
     private String receiverPartyId;
     private TradeParty seller;

--- a/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/DeliveryInformation.java
+++ b/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/DeliveryInformation.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.extern.jackson.Jacksonized;
-import java.time.LocalDate;
+import java.time.OffsetDateTime;
 
 @Data
 @Builder
@@ -13,7 +13,7 @@ import java.time.LocalDate;
 @AllArgsConstructor
 @Jacksonized
 public class DeliveryInformation {
-    private LocalDate deliveryDate;
+    private OffsetDateTime deliveryDate;
     private String deliveryLocationId;
     private Address deliveryAddress;
     private String deliveryPartyName;

--- a/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/DocumentHeader.java
+++ b/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/DocumentHeader.java
@@ -5,7 +5,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.extern.jackson.Jacksonized;
-import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.Currency;
 
 @Data
 @Builder
@@ -14,11 +15,11 @@ import java.time.LocalDate;
 @Jacksonized
 public class DocumentHeader {
     private String documentNumber;
-    private LocalDate documentDate;
+    private OffsetDateTime documentDate;
     private String buyerReference;
     private String sellerReference;
     private String contractReference;
-    private String currency;
+    private Currency currency;
     private PaymentTerms paymentTerms;
     private DeliveryInformation delivery;
 }

--- a/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/PaymentTerms.java
+++ b/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/PaymentTerms.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.extern.jackson.Jacksonized;
-import java.time.LocalDate;
+import java.time.OffsetDateTime;
 
 @Data
 @Builder
@@ -14,7 +14,7 @@ import java.time.LocalDate;
 @Jacksonized
 public class PaymentTerms {
     private String description;
-    private LocalDate dueDate;
+    private OffsetDateTime dueDate;
     private String paymentMeansCode;
     private String accountNumber;
     private String accountName;


### PR DESCRIPTION
## Summary
- use `OffsetDateTime` for message, header, delivery and payment dates
- model `DocumentHeader` currency with `java.util.Currency`

## Testing
- `mvn -pl cii-model test` *(fails: jaxb2 source generation stalls in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68bab2ed2080832e9021281ccb0200dc