### PR TITLE
Use OffsetDateTime and Currency throughout messaging modules

### DIFF
--- a/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/GenerateCommand.java
+++ b/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/GenerateCommand.java
@@ -10,8 +10,9 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Currency;
 import java.util.Arrays;
 import java.util.concurrent.Callable;
 
@@ -118,7 +119,7 @@ public class GenerateCommand extends AbstractCommand implements Callable<Integer
         return CIIMessage.builder()
                 .messageId("MSG-" + System.currentTimeMillis())
                 .messageType(messageType)
-                .creationDateTime(LocalDateTime.now())
+                  .creationDateTime(OffsetDateTime.now(ZoneOffset.UTC))
                 .senderPartyId(senderPartyId)
                 .receiverPartyId(receiverPartyId)
                 .header(createSampleHeader())
@@ -130,13 +131,13 @@ public class GenerateCommand extends AbstractCommand implements Callable<Integer
     private DocumentHeader createSampleHeader() {
         return DocumentHeader.builder()
                 .documentNumber("DOC-" + System.currentTimeMillis())
-                .documentDate(LocalDate.now())
-                .currency("EUR")
+                  .documentDate(OffsetDateTime.now(ZoneOffset.UTC))
+                  .currency(Currency.getInstance("EUR"))
                 .buyerReference("BUY-REF-001")
                 .sellerReference("SEL-REF-001")
                 .paymentTerms(PaymentTerms.builder()
                         .description("30 days net")
-                        .dueDate(LocalDate.now().plusDays(30))
+                          .dueDate(OffsetDateTime.now(ZoneOffset.UTC).plusDays(30))
                         .build())
                 .build();
     }

--- a/cii-messaging-parent/cii-model/src/test/java/com/cii/messaging/model/CIIMessageTest.java
+++ b/cii-messaging-parent/cii-model/src/test/java/com/cii/messaging/model/CIIMessageTest.java
@@ -3,8 +3,9 @@ package com.cii.messaging.model;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Currency;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -14,7 +15,7 @@ class CIIMessageTest {
     private DocumentHeader sampleHeader() {
         PaymentTerms terms = PaymentTerms.builder()
                 .description("Net 30")
-                .dueDate(LocalDate.of(2023, 6, 15))
+                .dueDate(OffsetDateTime.of(2023, 6, 15, 0, 0, 0, 0, ZoneOffset.UTC))
                 .paymentMeansCode("30")
                 .accountNumber("123456")
                 .accountName("Main Account")
@@ -22,7 +23,7 @@ class CIIMessageTest {
                 .build();
 
         DeliveryInformation delivery = DeliveryInformation.builder()
-                .deliveryDate(LocalDate.of(2023, 5, 20))
+                  .deliveryDate(OffsetDateTime.of(2023, 5, 20, 0, 0, 0, 0, ZoneOffset.UTC))
                 .deliveryLocationId("LOC1")
                 .deliveryAddress(Address.builder()
                         .street("123 Main St")
@@ -36,11 +37,11 @@ class CIIMessageTest {
 
         return DocumentHeader.builder()
                 .documentNumber("INV-1")
-                .documentDate(LocalDate.of(2023, 5, 1))
+                  .documentDate(OffsetDateTime.of(2023, 5, 1, 0, 0, 0, 0, ZoneOffset.UTC))
                 .buyerReference("BUYER")
                 .sellerReference("SELLER")
                 .contractReference("CONTRACT")
-                .currency("USD")
+                  .currency(Currency.getInstance("USD"))
                 .paymentTerms(terms)
                 .delivery(delivery)
                 .build();
@@ -111,7 +112,7 @@ class CIIMessageTest {
         DocumentHeader header = sampleHeader();
         LineItem lineItem = sampleLineItem();
         TotalsInformation totals = sampleTotals();
-        LocalDateTime timestamp = LocalDateTime.of(2023, 5, 1, 12, 0);
+          OffsetDateTime timestamp = OffsetDateTime.of(2023, 5, 1, 12, 0, 0, 0, ZoneOffset.UTC);
 
         CIIMessage message = CIIMessage.builder()
                 .messageId("MSG1")
@@ -128,7 +129,7 @@ class CIIMessageTest {
 
         assertEquals("MSG1", message.getMessageId());
         assertEquals(MessageType.INVOICE, message.getMessageType());
-        assertEquals(timestamp, message.getCreationDateTime());
+          assertEquals(timestamp, message.getCreationDateTime());
         assertEquals("SENDER", message.getSenderPartyId());
         assertEquals("RECEIVER", message.getReceiverPartyId());
         assertEquals("Seller", message.getSeller().getName());
@@ -146,7 +147,7 @@ class CIIMessageTest {
         LineItem item2 = sampleLineItem();
         TotalsInformation totals1 = sampleTotals();
         TotalsInformation totals2 = sampleTotals();
-        LocalDateTime timestamp = LocalDateTime.of(2023, 5, 1, 12, 0);
+          OffsetDateTime timestamp = OffsetDateTime.of(2023, 5, 1, 12, 0, 0, 0, ZoneOffset.UTC);
 
         CIIMessage message1 = CIIMessage.builder()
                 .messageId("MSG1")

--- a/cii-messaging-parent/cii-model/src/test/java/com/cii/messaging/model/DeliveryInformationTest.java
+++ b/cii-messaging-parent/cii-model/src/test/java/com/cii/messaging/model/DeliveryInformationTest.java
@@ -2,7 +2,8 @@ package com.cii.messaging.model;
 
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -18,7 +19,7 @@ class DeliveryInformationTest {
                 .countryName("United States")
                 .build();
 
-        LocalDate date = LocalDate.of(2023, 5, 20);
+        OffsetDateTime date = OffsetDateTime.of(2023, 5, 20, 0, 0, 0, 0, ZoneOffset.UTC);
 
         DeliveryInformation info = DeliveryInformation.builder()
                 .deliveryDate(date)
@@ -44,21 +45,21 @@ class DeliveryInformationTest {
                 .build();
 
         DeliveryInformation info1 = DeliveryInformation.builder()
-                .deliveryDate(LocalDate.of(2023, 5, 20))
+                .deliveryDate(OffsetDateTime.of(2023, 5, 20, 0, 0, 0, 0, ZoneOffset.UTC))
                 .deliveryLocationId("LOC1")
                 .deliveryAddress(address)
                 .deliveryPartyName("John Doe")
                 .build();
 
         DeliveryInformation info2 = DeliveryInformation.builder()
-                .deliveryDate(LocalDate.of(2023, 5, 20))
+                .deliveryDate(OffsetDateTime.of(2023, 5, 20, 0, 0, 0, 0, ZoneOffset.UTC))
                 .deliveryLocationId("LOC1")
                 .deliveryAddress(address)
                 .deliveryPartyName("John Doe")
                 .build();
 
         DeliveryInformation info3 = DeliveryInformation.builder()
-                .deliveryDate(LocalDate.of(2023, 5, 21))
+                .deliveryDate(OffsetDateTime.of(2023, 5, 21, 0, 0, 0, 0, ZoneOffset.UTC))
                 .deliveryLocationId("LOC2")
                 .deliveryAddress(address)
                 .deliveryPartyName("Jane Doe")

--- a/cii-messaging-parent/cii-model/src/test/java/com/cii/messaging/model/DocumentHeaderTest.java
+++ b/cii-messaging-parent/cii-model/src/test/java/com/cii/messaging/model/DocumentHeaderTest.java
@@ -2,7 +2,9 @@ package com.cii.messaging.model;
 
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Currency;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -11,7 +13,7 @@ class DocumentHeaderTest {
     private PaymentTerms samplePaymentTerms() {
         return PaymentTerms.builder()
                 .description("Net 30")
-                .dueDate(LocalDate.of(2023, 6, 15))
+                .dueDate(OffsetDateTime.of(2023, 6, 15, 0, 0, 0, 0, ZoneOffset.UTC))
                 .paymentMeansCode("30")
                 .accountNumber("123456")
                 .accountName("Main Account")
@@ -29,7 +31,7 @@ class DocumentHeaderTest {
                 .build();
 
         return DeliveryInformation.builder()
-                .deliveryDate(LocalDate.of(2023, 5, 20))
+                .deliveryDate(OffsetDateTime.of(2023, 5, 20, 0, 0, 0, 0, ZoneOffset.UTC))
                 .deliveryLocationId("LOC1")
                 .deliveryAddress(address)
                 .deliveryPartyName("John Doe")
@@ -43,21 +45,21 @@ class DocumentHeaderTest {
 
         DocumentHeader header = DocumentHeader.builder()
                 .documentNumber("INV-1")
-                .documentDate(LocalDate.of(2023, 5, 1))
+                .documentDate(OffsetDateTime.of(2023, 5, 1, 0, 0, 0, 0, ZoneOffset.UTC))
                 .buyerReference("BUYER")
                 .sellerReference("SELLER")
                 .contractReference("CONTRACT")
-                .currency("USD")
+                .currency(Currency.getInstance("USD"))
                 .paymentTerms(terms)
                 .delivery(delivery)
                 .build();
 
         assertEquals("INV-1", header.getDocumentNumber());
-        assertEquals(LocalDate.of(2023, 5, 1), header.getDocumentDate());
+        assertEquals(OffsetDateTime.of(2023, 5, 1, 0, 0, 0, 0, ZoneOffset.UTC), header.getDocumentDate());
         assertEquals("BUYER", header.getBuyerReference());
         assertEquals("SELLER", header.getSellerReference());
         assertEquals("CONTRACT", header.getContractReference());
-        assertEquals("USD", header.getCurrency());
+        assertEquals(Currency.getInstance("USD"), header.getCurrency());
         assertEquals(terms, header.getPaymentTerms());
         assertEquals(delivery, header.getDelivery());
     }
@@ -69,33 +71,33 @@ class DocumentHeaderTest {
 
         DocumentHeader header1 = DocumentHeader.builder()
                 .documentNumber("INV-1")
-                .documentDate(LocalDate.of(2023, 5, 1))
+                .documentDate(OffsetDateTime.of(2023, 5, 1, 0, 0, 0, 0, ZoneOffset.UTC))
                 .buyerReference("BUYER")
                 .sellerReference("SELLER")
                 .contractReference("CONTRACT")
-                .currency("USD")
+                .currency(Currency.getInstance("USD"))
                 .paymentTerms(terms)
                 .delivery(delivery)
                 .build();
 
         DocumentHeader header2 = DocumentHeader.builder()
                 .documentNumber("INV-1")
-                .documentDate(LocalDate.of(2023, 5, 1))
+                .documentDate(OffsetDateTime.of(2023, 5, 1, 0, 0, 0, 0, ZoneOffset.UTC))
                 .buyerReference("BUYER")
                 .sellerReference("SELLER")
                 .contractReference("CONTRACT")
-                .currency("USD")
+                .currency(Currency.getInstance("USD"))
                 .paymentTerms(terms)
                 .delivery(delivery)
                 .build();
 
         DocumentHeader header3 = DocumentHeader.builder()
                 .documentNumber("INV-2")
-                .documentDate(LocalDate.of(2023, 6, 1))
+                .documentDate(OffsetDateTime.of(2023, 6, 1, 0, 0, 0, 0, ZoneOffset.UTC))
                 .buyerReference("OTHER")
                 .sellerReference("SELLER")
                 .contractReference("CONTRACT")
-                .currency("EUR")
+                .currency(Currency.getInstance("EUR"))
                 .paymentTerms(terms)
                 .delivery(delivery)
                 .build();

--- a/cii-messaging-parent/cii-model/src/test/java/com/cii/messaging/model/PaymentTermsTest.java
+++ b/cii-messaging-parent/cii-model/src/test/java/com/cii/messaging/model/PaymentTermsTest.java
@@ -2,7 +2,8 @@ package com.cii.messaging.model;
 
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -10,7 +11,7 @@ class PaymentTermsTest {
 
     @Test
     void builderShouldSetFields() {
-        LocalDate due = LocalDate.of(2023, 6, 15);
+        OffsetDateTime due = OffsetDateTime.of(2023, 6, 15, 0, 0, 0, 0, ZoneOffset.UTC);
         PaymentTerms terms = PaymentTerms.builder()
                 .description("Net 30")
                 .dueDate(due)
@@ -32,7 +33,7 @@ class PaymentTermsTest {
     void equalsAndHashCodeShouldWork() {
         PaymentTerms terms1 = PaymentTerms.builder()
                 .description("Net 30")
-                .dueDate(LocalDate.of(2023, 6, 15))
+                .dueDate(OffsetDateTime.of(2023, 6, 15, 0, 0, 0, 0, ZoneOffset.UTC))
                 .paymentMeansCode("30")
                 .accountNumber("123456")
                 .accountName("Main Account")
@@ -41,7 +42,7 @@ class PaymentTermsTest {
 
         PaymentTerms terms2 = PaymentTerms.builder()
                 .description("Net 30")
-                .dueDate(LocalDate.of(2023, 6, 15))
+                .dueDate(OffsetDateTime.of(2023, 6, 15, 0, 0, 0, 0, ZoneOffset.UTC))
                 .paymentMeansCode("30")
                 .accountNumber("123456")
                 .accountName("Main Account")
@@ -50,7 +51,7 @@ class PaymentTermsTest {
 
         PaymentTerms terms3 = PaymentTerms.builder()
                 .description("Net 60")
-                .dueDate(LocalDate.of(2023, 7, 15))
+                .dueDate(OffsetDateTime.of(2023, 7, 15, 0, 0, 0, 0, ZoneOffset.UTC))
                 .paymentMeansCode("60")
                 .accountNumber("654321")
                 .accountName("Other Account")

--- a/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/impl/AbstractCIIReader.java
+++ b/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/impl/AbstractCIIReader.java
@@ -16,8 +16,6 @@ import java.io.File;
 import java.io.InputStream;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/impl/DesadvReader.java
+++ b/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/impl/DesadvReader.java
@@ -10,7 +10,8 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.File;
 import java.io.InputStream;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 
 public class DesadvReader extends AbstractCIIReader {
     
@@ -41,8 +42,8 @@ public class DesadvReader extends AbstractCIIReader {
     protected CIIMessage parseDocument(Object document) throws CIIReaderException {
         // Basic implementation for DESADV parsing
         return CIIMessage.builder()
-                .messageType(MessageType.DESADV)
-                .creationDateTime(LocalDateTime.now())
-                .build();
+                  .messageType(MessageType.DESADV)
+                  .creationDateTime(OffsetDateTime.now(ZoneOffset.UTC))
+                  .build();
     }
 }

--- a/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/impl/OrderReader.java
+++ b/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/impl/OrderReader.java
@@ -13,7 +13,9 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.File;
 import java.io.InputStream;
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Currency;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -69,7 +71,7 @@ public class OrderReader extends AbstractCIIReader {
         return CIIMessage.builder()
                 .messageId(extractMessageId(doc))
                 .messageType(MessageType.ORDER)
-                .creationDateTime(LocalDateTime.now())
+                  .creationDateTime(OffsetDateTime.now(ZoneOffset.UTC))
                 .senderPartyId(extractBuyerPartyId(doc))
                 .receiverPartyId(extractSellerPartyId(doc))
                 .header(extractOrderHeader(doc))
@@ -108,8 +110,8 @@ public class OrderReader extends AbstractCIIReader {
         return DocumentHeader.builder()
                 .documentNumber(extractMessageId(doc))
                 .buyerReference(extractTextContent(doc, "BuyerReference"))
-                .currency(extractTextContent(doc, "OrderCurrencyCode"))
-                .build();
+                  .currency(parseCurrency(extractTextContent(doc, "OrderCurrencyCode")))
+                  .build();
     }
     
     private List<LineItem> extractOrderLineItems(Document doc) {
@@ -189,5 +191,16 @@ public class OrderReader extends AbstractCIIReader {
             return nodes.item(0).getTextContent().trim();
         }
         return null;
+    }
+
+    private Currency parseCurrency(String code) {
+        if (code == null || code.isBlank()) {
+            return null;
+        }
+        try {
+            return Currency.getInstance(code);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 }

--- a/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/impl/OrderResponseReader.java
+++ b/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/impl/OrderResponseReader.java
@@ -10,7 +10,8 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.File;
 import java.io.InputStream;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 
 public class OrderResponseReader extends AbstractCIIReader {
     
@@ -41,8 +42,8 @@ public class OrderResponseReader extends AbstractCIIReader {
     protected CIIMessage parseDocument(Object document) throws CIIReaderException {
         // Basic implementation for ORDERSP parsing
         return CIIMessage.builder()
-                .messageType(MessageType.ORDERSP)
-                .creationDateTime(LocalDateTime.now())
-                .build();
+                  .messageType(MessageType.ORDERSP)
+                  .creationDateTime(OffsetDateTime.now(ZoneOffset.UTC))
+                  .build();
     }
 }

--- a/cii-messaging-parent/cii-reader/src/test/java/com/cii/messaging/reader/OrderReaderTest.java
+++ b/cii-messaging-parent/cii-reader/src/test/java/com/cii/messaging/reader/OrderReaderTest.java
@@ -9,6 +9,7 @@ import java.net.URL;
 import java.math.BigDecimal;
 
 import static org.junit.jupiter.api.Assertions.*;
+import java.util.Currency;
 
 public class OrderReaderTest {
 
@@ -19,9 +20,9 @@ public class OrderReaderTest {
         assertNotNull(resource);
         File file = new File(resource.toURI());
         CIIMessage message = reader.read(file);
-        assertNotNull(message.getHeader());
-        assertEquals("EUR", message.getHeader().getCurrency());
-    }
+          assertNotNull(message.getHeader());
+          assertEquals(Currency.getInstance("EUR"), message.getHeader().getCurrency());
+      }
 
     @Test
     void extractsLineTotalFromHeader() throws Exception {

--- a/cii-messaging-parent/cii-samples/src/test/java/com/cii/messaging/integration/CIIIntegrationTest.java
+++ b/cii-messaging-parent/cii-samples/src/test/java/com/cii/messaging/integration/CIIIntegrationTest.java
@@ -11,8 +11,9 @@ import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Currency;
 import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.*;
@@ -163,17 +164,17 @@ class CIIIntegrationTest {
         return CIIMessage.builder()
                 .messageId("INV-TEST-001")
                 .messageType(MessageType.INVOICE)
-                .creationDateTime(LocalDateTime.now())
+                  .creationDateTime(OffsetDateTime.now(ZoneOffset.UTC))
                 .senderPartyId("SELLER001")
                 .receiverPartyId("BUYER001")
                 .header(DocumentHeader.builder()
                         .documentNumber("INV-2024-001")
-                        .documentDate(LocalDate.now())
+                          .documentDate(OffsetDateTime.now(ZoneOffset.UTC))
                         .buyerReference("BR-REF-001")
-                        .currency("EUR")
+                          .currency(Currency.getInstance("EUR"))
                         .paymentTerms(PaymentTerms.builder()
                                 .description("30 days net")
-                                .dueDate(LocalDate.now().plusDays(30))
+                                  .dueDate(OffsetDateTime.now(ZoneOffset.UTC).plusDays(30))
                                 .build())
                         .build())
                 .lineItems(Arrays.asList(

--- a/cii-messaging-parent/cii-service/src/main/java/com/cii/messaging/service/impl/CIIMessagingServiceImpl.java
+++ b/cii-messaging-parent/cii-service/src/main/java/com/cii/messaging/service/impl/CIIMessagingServiceImpl.java
@@ -13,8 +13,8 @@ import org.slf4j.LoggerFactory;
 import java.io.*;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -161,7 +161,7 @@ public class CIIMessagingServiceImpl implements CIIMessagingService {
             CIIMessage invoice = CIIMessage.builder()
                     .messageId(generateMessageId())
                     .messageType(MessageType.INVOICE)
-                    .creationDateTime(LocalDateTime.now())
+                      .creationDateTime(OffsetDateTime.now(ZoneOffset.UTC))
                     .senderPartyId(order.getReceiverPartyId()) // Swap sender/receiver
                     .receiverPartyId(order.getSenderPartyId())
                     .header(createInvoiceHeader(order.getHeader()))
@@ -185,7 +185,7 @@ public class CIIMessagingServiceImpl implements CIIMessagingService {
             CIIMessage desadv = CIIMessage.builder()
                     .messageId(generateMessageId())
                     .messageType(MessageType.DESADV)
-                    .creationDateTime(LocalDateTime.now())
+                      .creationDateTime(OffsetDateTime.now(ZoneOffset.UTC))
                     .senderPartyId(order.getReceiverPartyId())
                     .receiverPartyId(order.getSenderPartyId())
                     .header(createDesadvHeader(order.getHeader()))
@@ -208,7 +208,7 @@ public class CIIMessagingServiceImpl implements CIIMessagingService {
             CIIMessage ordersp = CIIMessage.builder()
                     .messageId(generateMessageId())
                     .messageType(MessageType.ORDERSP)
-                    .creationDateTime(LocalDateTime.now())
+                      .creationDateTime(OffsetDateTime.now(ZoneOffset.UTC))
                     .senderPartyId(order.getReceiverPartyId())
                     .receiverPartyId(order.getSenderPartyId())
                     .header(createOrderResponseHeader(order.getHeader(), responseType))
@@ -234,7 +234,7 @@ public class CIIMessagingServiceImpl implements CIIMessagingService {
         
         return DocumentHeader.builder()
                 .documentNumber("INV-" + UUID.randomUUID().toString().substring(0, 8))
-                .documentDate(LocalDate.now())
+                  .documentDate(OffsetDateTime.now(ZoneOffset.UTC))
                 .buyerReference(orderHeader.getBuyerReference())
                 .sellerReference(orderHeader.getSellerReference())
                 .contractReference(orderHeader.getContractReference())
@@ -251,7 +251,7 @@ public class CIIMessagingServiceImpl implements CIIMessagingService {
         
         return DocumentHeader.builder()
                 .documentNumber("DES-" + UUID.randomUUID().toString().substring(0, 8))
-                .documentDate(LocalDate.now())
+                  .documentDate(OffsetDateTime.now(ZoneOffset.UTC))
                 .buyerReference(orderHeader.getBuyerReference())
                 .sellerReference(orderHeader.getSellerReference())
                 .delivery(orderHeader.getDelivery())
@@ -265,7 +265,7 @@ public class CIIMessagingServiceImpl implements CIIMessagingService {
         
         return DocumentHeader.builder()
                 .documentNumber("ORD-RSP-" + UUID.randomUUID().toString().substring(0, 8))
-                .documentDate(LocalDate.now())
+                .documentDate(OffsetDateTime.now(ZoneOffset.UTC))
                 .buyerReference(orderHeader.getBuyerReference())
                 .sellerReference(orderHeader.getSellerReference())
                 .build();

--- a/cii-messaging-parent/cii-service/src/test/java/com/cii/messaging/service/impl/CIIMessagingServiceImplTest.java
+++ b/cii-messaging-parent/cii-service/src/test/java/com/cii/messaging/service/impl/CIIMessagingServiceImplTest.java
@@ -4,7 +4,8 @@ import com.cii.messaging.model.CIIMessage;
 import com.cii.messaging.model.MessageType;
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -17,7 +18,7 @@ class CIIMessagingServiceImplTest {
         CIIMessage original = CIIMessage.builder()
                 .messageId("123")
                 .messageType(MessageType.ORDER)
-                .creationDateTime(LocalDateTime.now())
+                  .creationDateTime(OffsetDateTime.now(ZoneOffset.UTC))
                 .build();
 
         String json = service.convertToJson(original);

--- a/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/validator/impl/BusinessRulesValidatorTest.java
+++ b/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/validator/impl/BusinessRulesValidatorTest.java
@@ -12,7 +12,8 @@ import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -66,7 +67,7 @@ class BusinessRulesValidatorTest {
     void validateMessageMissingRequiredReferences() {
         CIIMessage message = CIIMessage.builder()
                 .header(DocumentHeader.builder()
-                        .documentDate(LocalDate.now())
+                          .documentDate(OffsetDateTime.now(ZoneOffset.UTC))
                         .build())
                 .lineItems(List.of(LineItem.builder()
                         .lineNumber("1")
@@ -94,7 +95,7 @@ class BusinessRulesValidatorTest {
         CIIMessage message = CIIMessage.builder()
                 .header(DocumentHeader.builder()
                         .documentNumber("INV-1")
-                        .documentDate(LocalDate.now())
+                          .documentDate(OffsetDateTime.now(ZoneOffset.UTC))
                         .buyerReference("BUY-1")
                         .build())
                 .lineItems(List.of(LineItem.builder()
@@ -125,7 +126,7 @@ class BusinessRulesValidatorTest {
         CIIMessage message = CIIMessage.builder()
                 .header(DocumentHeader.builder()
                         .documentNumber("INV-2")
-                        .documentDate(LocalDate.now())
+                          .documentDate(OffsetDateTime.now(ZoneOffset.UTC))
                         .buyerReference("BUY-2")
                         .build())
                 .lineItems(List.of(LineItem.builder()

--- a/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/validator/impl/CompositeValidatorTest.java
+++ b/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/validator/impl/CompositeValidatorTest.java
@@ -8,7 +8,8 @@ import org.junit.jupiter.api.Test;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -150,7 +151,7 @@ class CompositeValidatorTest {
         CIIMessage msg = CIIMessage.builder()
                 .messageId("1")
                 .messageType(MessageType.INVOICE)
-                .creationDateTime(LocalDateTime.now())
+                  .creationDateTime(OffsetDateTime.now(ZoneOffset.UTC))
                 .senderPartyId("S")
                 .receiverPartyId("R")
                 .build();

--- a/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/validator/impl/SchematronValidatorTest.java
+++ b/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/validator/impl/SchematronValidatorTest.java
@@ -12,7 +12,8 @@ import org.junit.jupiter.api.AfterAll;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -69,7 +70,7 @@ class SchematronValidatorTest {
         CIIMessage message = CIIMessage.builder()
                 .messageId("INV-1")
                 .messageType(MessageType.INVOICE)
-                .creationDateTime(LocalDateTime.now())
+                  .creationDateTime(OffsetDateTime.now(ZoneOffset.UTC))
                 .build();
         ValidationResult result = validator.validate(message);
         assertTrue(result.isValid());

--- a/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/validator/impl/XSDValidatorTest.java
+++ b/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/validator/impl/XSDValidatorTest.java
@@ -16,7 +16,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -55,7 +56,7 @@ class XSDValidatorTest {
         CIIMessage message = CIIMessage.builder()
                 .messageId("INV-1")
                 .messageType(MessageType.INVOICE)
-                .creationDateTime(LocalDateTime.now())
+                  .creationDateTime(OffsetDateTime.now(ZoneOffset.UTC))
                 .build();
         XSDValidator validator = new XSDValidator();
         ValidationResult result = validator.validate(message);

--- a/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/impl/DesadvWriter.java
+++ b/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/impl/DesadvWriter.java
@@ -14,7 +14,8 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import java.io.OutputStream;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 
 public class DesadvWriter extends AbstractCIIWriter {
@@ -73,11 +74,11 @@ public class DesadvWriter extends AbstractCIIWriter {
             addElement(doc, exchangedDoc, "ram:ID", message.getMessageId());
             addElement(doc, exchangedDoc, "ram:TypeCode", "351"); // Despatch advice type code
 
-            Element issueDateTime = createElement(doc, "ram:IssueDateTime");
-            Element dateTimeString = createElement(doc, "udt:DateTimeString");
-            dateTimeString.setAttribute("format", "102");
-            dateTimeString.setTextContent(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss")));
-            issueDateTime.appendChild(dateTimeString);
+              Element issueDateTime = createElement(doc, "ram:IssueDateTime");
+              Element dateTimeString = createElement(doc, "udt:DateTimeString");
+              dateTimeString.setAttribute("format", "102");
+              dateTimeString.setTextContent(OffsetDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss")));
+              issueDateTime.appendChild(dateTimeString);
             exchangedDoc.appendChild(issueDateTime);
 
             // Add SupplyChainTradeTransaction

--- a/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/impl/InvoiceWriter.java
+++ b/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/impl/InvoiceWriter.java
@@ -105,7 +105,7 @@ public class InvoiceWriter extends AbstractCIIWriter {
             // Add line items
             if (message.getLineItems() != null) {
                 for (LineItem lineItem : message.getLineItems()) {
-                    Element lineElement = createLineItemElement(doc, lineItem, header.getCurrency());
+                      Element lineElement = createLineItemElement(doc, lineItem, header.getCurrency() != null ? header.getCurrency().getCurrencyCode() : null);
                     transaction.appendChild(lineElement);
                 }
             }
@@ -146,7 +146,7 @@ public class InvoiceWriter extends AbstractCIIWriter {
             Element headerSettlement = createElement(doc, "ram:ApplicableHeaderTradeSettlement");
             transaction.appendChild(headerSettlement);
 
-            addElement(doc, headerSettlement, "ram:InvoiceCurrencyCode", header.getCurrency());
+              addElement(doc, headerSettlement, "ram:InvoiceCurrencyCode", header.getCurrency() != null ? header.getCurrency().getCurrencyCode() : null);
 
             if (header.getPaymentTerms() != null) {
                 PaymentTerms terms = header.getPaymentTerms();
@@ -168,11 +168,11 @@ public class InvoiceWriter extends AbstractCIIWriter {
                 Element monetarySummation = createElement(doc, "ram:SpecifiedTradeSettlementHeaderMonetarySummation");
                 headerSettlement.appendChild(monetarySummation);
 
-            addAmountElement(doc, monetarySummation, "ram:LineTotalAmount", message.getTotals().getLineTotalAmount(), header.getCurrency(), false);
-                addAmountElement(doc, monetarySummation, "ram:TaxBasisTotalAmount", message.getTotals().getTaxBasisAmount(), header.getCurrency(), false);
-                addAmountElement(doc, monetarySummation, "ram:TaxTotalAmount", message.getTotals().getTaxTotalAmount(), header.getCurrency(), true);
-                addAmountElement(doc, monetarySummation, "ram:GrandTotalAmount", message.getTotals().getGrandTotalAmount(), header.getCurrency(), false);
-                addAmountElement(doc, monetarySummation, "ram:DuePayableAmount", message.getTotals().getDuePayableAmount(), header.getCurrency(), false);
+              addAmountElement(doc, monetarySummation, "ram:LineTotalAmount", message.getTotals().getLineTotalAmount(), header.getCurrency() != null ? header.getCurrency().getCurrencyCode() : null, false);
+                  addAmountElement(doc, monetarySummation, "ram:TaxBasisTotalAmount", message.getTotals().getTaxBasisAmount(), header.getCurrency() != null ? header.getCurrency().getCurrencyCode() : null, false);
+                  addAmountElement(doc, monetarySummation, "ram:TaxTotalAmount", message.getTotals().getTaxTotalAmount(), header.getCurrency() != null ? header.getCurrency().getCurrencyCode() : null, true);
+                  addAmountElement(doc, monetarySummation, "ram:GrandTotalAmount", message.getTotals().getGrandTotalAmount(), header.getCurrency() != null ? header.getCurrency().getCurrencyCode() : null, false);
+                  addAmountElement(doc, monetarySummation, "ram:DuePayableAmount", message.getTotals().getDuePayableAmount(), header.getCurrency() != null ? header.getCurrency().getCurrencyCode() : null, false);
             }
             
             return doc;

--- a/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/impl/DesadvWriterTest.java
+++ b/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/impl/DesadvWriterTest.java
@@ -11,8 +11,8 @@ import javax.xml.validation.Validator;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.net.URL;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -32,7 +32,7 @@ public class DesadvWriterTest {
         return CIIMessage.builder()
                 .messageId("MSG-DESADV")
                 .messageType(MessageType.DESADV)
-                .creationDateTime(LocalDateTime.parse("20240201120000", DateTimeFormatter.ofPattern("yyyyMMddHHmmss")))
+                  .creationDateTime(OffsetDateTime.of(2024, 2, 1, 12, 0, 0, 0, ZoneOffset.UTC))
                 .senderPartyId("SELLER")
                 .receiverPartyId("BUYER")
                 .lineItems(java.util.List.of(line))

--- a/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/impl/InvoiceWriterTest.java
+++ b/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/impl/InvoiceWriterTest.java
@@ -4,9 +4,9 @@ import com.cii.messaging.model.*;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Currency;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -44,12 +44,12 @@ public class InvoiceWriterTest {
                         .build())
                 .build();
 
-        DocumentHeader header = DocumentHeader.builder()
-                .documentNumber("INV-2024-001")
-                .documentDate(LocalDate.now())
-                .buyerReference("BUY-REF-2024-001")
-                .currency("EUR")
-                .build();
+          DocumentHeader header = DocumentHeader.builder()
+                  .documentNumber("INV-2024-001")
+                  .documentDate(OffsetDateTime.now(ZoneOffset.UTC))
+                  .buyerReference("BUY-REF-2024-001")
+                  .currency(Currency.getInstance("EUR"))
+                  .build();
 
         LineItem line = LineItem.builder()
                 .lineNumber("1")
@@ -75,7 +75,7 @@ public class InvoiceWriterTest {
         return CIIMessage.builder()
                 .messageId("MSG1")
                 .messageType(MessageType.INVOICE)
-                .creationDateTime(LocalDateTime.parse("20240201120000", DateTimeFormatter.ofPattern("yyyyMMddHHmmss")))
+                  .creationDateTime(OffsetDateTime.of(2024, 2, 1, 12, 0, 0, 0, ZoneOffset.UTC))
                 .senderPartyId(seller.getId())
                 .receiverPartyId(buyer.getId())
                 .seller(seller)

--- a/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/impl/OrderResponseWriterTest.java
+++ b/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/impl/OrderResponseWriterTest.java
@@ -11,8 +11,8 @@ import javax.xml.validation.Validator;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.net.URL;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -36,7 +36,7 @@ public class OrderResponseWriterTest {
         return CIIMessage.builder()
                 .messageId("MSG-ORDERSP")
                 .messageType(MessageType.ORDERSP)
-                .creationDateTime(LocalDateTime.parse("20240201120000", DateTimeFormatter.ofPattern("yyyyMMddHHmmss")))
+                  .creationDateTime(OffsetDateTime.of(2024, 2, 1, 12, 0, 0, 0, ZoneOffset.UTC))
                 .seller(TradeParty.builder().id("SELLER").name("Seller Corp").build())
                 .buyer(TradeParty.builder().id("BUYER").name("Buyer Corp").build())
                 .header(header)

--- a/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/impl/OrderWriterTest.java
+++ b/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/impl/OrderWriterTest.java
@@ -11,9 +11,9 @@ import javax.xml.validation.Validator;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Currency;
 import java.net.URL;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -32,12 +32,12 @@ public class OrderWriterTest {
                 .name("Buyer Corp")
                 .build();
 
-        DocumentHeader header = DocumentHeader.builder()
-                .documentNumber("ORD-2024-001")
-                .documentDate(LocalDate.now())
-                .buyerReference("BR-2024")
-                .currency("EUR")
-                .build();
+          DocumentHeader header = DocumentHeader.builder()
+                  .documentNumber("ORD-2024-001")
+                  .documentDate(OffsetDateTime.now(ZoneOffset.UTC))
+                  .buyerReference("BR-2024")
+                  .currency(Currency.getInstance("EUR"))
+                  .build();
 
         LineItem line = LineItem.builder()
                 .lineNumber("1")
@@ -55,7 +55,7 @@ public class OrderWriterTest {
         return CIIMessage.builder()
                 .messageId("MSG-ORDER")
                 .messageType(MessageType.ORDER)
-                .creationDateTime(LocalDateTime.parse("20240201120000", DateTimeFormatter.ofPattern("yyyyMMddHHmmss")))
+                  .creationDateTime(OffsetDateTime.of(2024, 2, 1, 12, 0, 0, 0, ZoneOffset.UTC))
                 .seller(seller)
                 .buyer(buyer)
                 .header(header)


### PR DESCRIPTION
## Summary
- Replace `LocalDate`/`LocalDateTime` with `OffsetDateTime` across tests and services
- Parse and format ISO currency codes with `java.util.Currency`
- Adjust readers, writers, CLI, and validators accordingly to new types

## Testing
- `mvn test`


------
https://chatgpt.com/codex/tasks/task_e_68bab502c41c832e9c17c0be5f1515e7