### PR TITLE
Generate JAXB model for all UNECE schemas

### DIFF
--- a/cii-messaging-parent/cii-model/pom.xml
+++ b/cii-messaging-parent/cii-model/pom.xml
@@ -62,36 +62,69 @@
             </resource>
           </resources>
           <plugins>
-	    <plugin>
-	      <groupId>org.codehaus.mojo</groupId>
-	      <artifactId>jaxb2-maven-plugin</artifactId>
-	      <version>3.3.0</version>
-	      <executions>
-	        <execution>
-	          <id>generate-jaxb-sources</id>
-	          <phase>generate-sources</phase>
-	          <goals>
-	            <goal>xjc</goal>
-	          </goals>
-	          <configuration>
-                    <sources>${basedir}/src/main/resources/xsd/${unece.version}</sources>
-                    <packageName>com.cii.messaging.unece</packageName>
-			     <xjbSources>
-			      <!-- ici on pointe vers votre fichier bindings.xjb -->
-			      <xjbSource>${basedir}/src/main/resources/bindings/bindings.xjb</xjbSource>
-			    </xjbSources>
-	            <!-- Autoriser les extensions et désactiver la validation stricte -->
-		        <extension>true</extension>
-		        <arguments>
-		          <!-- -nv : non-validating without strict schema checking -->
-		          <argument>-nv</argument>
-		          <!-- résout automatiquement les collisions de noms -->
-          		  <argument>-XautoNameResolution</argument>
-		        </arguments>
-	          </configuration>
-	        </execution>
-	      </executions>
-	    </plugin>
+            <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>jaxb2-maven-plugin</artifactId>
+              <version>3.3.0</version>
+              <configuration>
+                <packageName>com.cii.messaging.unece</packageName>
+                <clearOutputDir>false</clearOutputDir>
+                <xjbSources>
+                  <!-- ici on pointe vers votre fichier bindings.xjb -->
+                  <xjbSource>${basedir}/src/main/resources/bindings/bindings.xjb</xjbSource>
+                </xjbSources>
+                <!-- Autoriser les extensions et désactiver la validation stricte -->
+                <extension>true</extension>
+                <arguments>
+                  <!-- -nv : non-validating without strict schema checking -->
+                  <argument>-nv</argument>
+                  <!-- résout automatiquement les collisions de noms -->
+                  <argument>-XautoNameResolution</argument>
+                </arguments>
+              </configuration>
+              <executions>
+                <execution>
+                  <id>generate-invoice</id>
+                  <phase>generate-sources</phase>
+                  <goals><goal>xjc</goal></goals>
+                  <configuration>
+                    <sources>
+                      <source>${basedir}/src/main/resources/xsd/${unece.version}/CrossIndustryInvoice_100p${unece.version}.xsd</source>
+                    </sources>
+                  </configuration>
+                </execution>
+                <execution>
+                  <id>generate-order</id>
+                  <phase>generate-sources</phase>
+                  <goals><goal>xjc</goal></goals>
+                  <configuration>
+                    <sources>
+                      <source>${basedir}/src/main/resources/xsd/${unece.version}/CrossIndustryOrder_100p${unece.version}.xsd</source>
+                    </sources>
+                  </configuration>
+                </execution>
+                <execution>
+                  <id>generate-order-response</id>
+                  <phase>generate-sources</phase>
+                  <goals><goal>xjc</goal></goals>
+                  <configuration>
+                    <sources>
+                      <source>${basedir}/src/main/resources/xsd/${unece.version}/CrossIndustryOrderResponse_100p${unece.version}.xsd</source>
+                    </sources>
+                  </configuration>
+                </execution>
+                <execution>
+                  <id>generate-despatch-advice</id>
+                  <phase>generate-sources</phase>
+                  <goals><goal>xjc</goal></goals>
+                  <configuration>
+                    <sources>
+                      <source>${basedir}/src/main/resources/xsd/${unece.version}/CrossIndustryDespatchAdvice_100p${unece.version}.xsd</source>
+                    </sources>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
 	
 	    <plugin>
 	      <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
## Summary
- Generate JAXB classes from all primary UNECE schema files (Invoice, Order, OrderResponse, DespatchAdvice)
- Share common JAXB configuration and prevent output cleanup between executions

## Testing
- `mvn -f cii-messaging-parent/pom.xml -pl cii-model generate-sources`
- `mvn -f cii-messaging-parent/pom.xml -pl cii-model test`


------
https://chatgpt.com/codex/tasks/task_e_68c7faaa6cc8832eb828d2b1c20f3be3