### PR TITLE
feat(model): add dedicated document models

### DIFF
--- a/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/despatchadvice/DespatchAdvice.java
+++ b/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/despatchadvice/DespatchAdvice.java
@@ -1,0 +1,13 @@
+package com.cii.messaging.model.despatchadvice;
+
+import com.cii.messaging.unece.despatchadvice.CrossIndustryDespatchAdviceType;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Dedicated model for despatch advice based on UNECE CrossIndustryDespatchAdviceType.
+ */
+@XmlRootElement(name = "CrossIndustryDespatchAdvice")
+public class DespatchAdvice extends CrossIndustryDespatchAdviceType {
+    // Additional domain-specific helpers or validations can be added here later.
+}

--- a/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/invoice/Invoice.java
+++ b/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/invoice/Invoice.java
@@ -1,0 +1,13 @@
+package com.cii.messaging.model.invoice;
+
+import com.cii.messaging.unece.invoice.CrossIndustryInvoiceType;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Dedicated model for invoices based on UNECE CrossIndustryInvoiceType.
+ */
+@XmlRootElement(name = "CrossIndustryInvoice")
+public class Invoice extends CrossIndustryInvoiceType {
+    // Additional domain-specific helpers or validations can be added here later.
+}

--- a/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/order/Order.java
+++ b/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/order/Order.java
@@ -1,0 +1,13 @@
+package com.cii.messaging.model.order;
+
+import com.cii.messaging.unece.order.CrossIndustryOrderType;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Dedicated model for orders based on UNECE CrossIndustryOrderType.
+ */
+@XmlRootElement(name = "CrossIndustryOrder")
+public class Order extends CrossIndustryOrderType {
+    // Additional domain-specific helpers or validations can be added here later.
+}

--- a/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/orderresponse/OrderResponse.java
+++ b/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/orderresponse/OrderResponse.java
@@ -1,0 +1,13 @@
+package com.cii.messaging.model.orderresponse;
+
+import com.cii.messaging.unece.orderresponse.CrossIndustryOrderResponseType;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Dedicated model for order responses based on UNECE CrossIndustryOrderResponseType.
+ */
+@XmlRootElement(name = "CrossIndustryOrderResponse")
+public class OrderResponse extends CrossIndustryOrderResponseType {
+    // Additional domain-specific helpers or validations can be added here later.
+}


### PR DESCRIPTION
## Summary
- add dedicated wrappers for Invoice, Order, OrderResponse, and DespatchAdvice based on generated UNECE types

## Testing
- `mvn -pl cii-model test -e`


------
https://chatgpt.com/codex/tasks/task_e_68c80dfc7f7c832e82e45ca1773ba2bf