### PR TITLE
feat: add UNECE schema loader

### DIFF
--- a/cii-messaging-parent/README.md
+++ b/cii-messaging-parent/README.md
@@ -61,6 +61,85 @@ InvoiceWriter writer = new InvoiceWriter();
 writer.write(invoice, new File("invoice-out.xml"));
 ```
 
+### Chargement manuel des schémas
+
+```java
+Schema schema = UneceSchemaLoader.loadSchema("CrossIndustryInvoice.xsd");
+// Le chargeur résout automatiquement le suffixe spécifique à la version
+```
+
+## 🚀 Déploiement
+
+### Utilisation de la CLI
+
+```bash
+java -jar cii-cli/target/cii-cli-1.0.0-SNAPSHOT-jar-with-dependencies.jar --help
+```
+
+### Utilisation comme bibliothèque Maven
+
+```xml
+<dependency>
+  <groupId>com.cii.messaging</groupId>
+  <artifactId>cii-service</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+</dependency>
+```
+
+## 🤖 Scripts
+
+### `scripts/build.sh`
+Build Maven complet (tests ignorés) et copie du JAR de la CLI dans `dist/cii-cli.jar`.
+
+```bash
+./scripts/build.sh
+```
+
+### `scripts/run-cli.sh`
+Wrapper pour lancer la CLI depuis `dist`. À utiliser après le build.
+
+```bash
+./scripts/run-cli.sh --help
+```
+
+### `scripts/validate-all.sh`
+Valide tous les fichiers XML d'un répertoire via la CLI. Dépend de `dist/cii-cli.jar` généré par le build.
+
+```bash
+./scripts/validate-all.sh cii-samples/src/main/resources/samples
+```
+
+## 📝 Exemples d'utilisation
+
+### Lecture d'un message
+
+```bash
+# ORDER
+java -jar cii-cli.jar parse cii-samples/src/main/resources/samples/order-sample.xml
+
+# INVOICE
+java -jar cii-cli.jar parse cii-samples/src/main/resources/samples/invoice-sample.xml
+```
+
+### Génération de messages avec la CLI
+
+```bash
+# Générer une facture (INVOICE) à partir d'une commande
+java -jar cii-cli.jar generate INVOICE \
+  --from-order cii-samples/src/main/resources/samples/order-sample.xml \
+  --output invoice.xml
+
+# Générer un avis d'expédition (DESADV)
+java -jar cii-cli.jar generate DESADV \
+  --from-order cii-samples/src/main/resources/samples/order-sample.xml \
+  --output desadv.xml
+
+# Générer une réponse à commande (ORDERSP)
+java -jar cii-cli.jar generate ORDERSP \
+  --from-order cii-samples/src/main/resources/samples/order-sample.xml \
+  --output ordersp.xml
+```
+
 ## 📑 Schémas XSD
 
 Les schémas nécessaires se trouvent dans `cii-model/src/main/resources/xsd/VERSION/` :

--- a/cii-messaging-parent/cii-validator/src/main/java/com/cii/messaging/validator/UneceSchemaLoader.java
+++ b/cii-messaging-parent/cii-validator/src/main/java/com/cii/messaging/validator/UneceSchemaLoader.java
@@ -1,0 +1,52 @@
+package com.cii.messaging.validator;
+
+import javax.xml.XMLConstants;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+import org.xml.sax.SAXException;
+
+/**
+ * Utility class to load UNECE XSD schemas according to the configured version.
+ */
+public final class UneceSchemaLoader {
+
+    private UneceSchemaLoader() {
+        // Utility class
+    }
+
+    /**
+     * Loads an XSD schema from the classpath for the current UNECE version.
+     * <p>
+     * The loader automatically appends the "_100pVERSION" suffix to the provided
+     * XSD name and searches under <code>/xsd/VERSION/</code>.
+     * </p>
+     *
+     * @param xsdName base XSD file name (e.g. "CrossIndustryInvoice.xsd")
+     * @return loaded {@link Schema}
+     * @throws IOException   if the resource cannot be found
+     * @throws SAXException  if the XSD cannot be parsed
+     */
+    public static Schema loadSchema(String xsdName) throws IOException, SAXException {
+        String version = SchemaVersion.getDefault().getVersion();
+        String baseName = xsdName.endsWith(".xsd") ? xsdName.substring(0, xsdName.length() - 4) : xsdName;
+        String resourcePath = String.format("/xsd/%s/%s_100p%s.xsd", version, baseName, version);
+
+        URL url = UneceSchemaLoader.class.getResource(resourcePath);
+        if (url == null) {
+            throw new IOException("Schéma introuvable : " + resourcePath);
+        }
+
+        try (InputStream is = url.openStream()) {
+            SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+            StreamSource source = new StreamSource(is, url.toExternalForm());
+            return factory.newSchema(source);
+        }
+    }
+}
+

--- a/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/validator/UneceSchemaLoaderTest.java
+++ b/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/validator/UneceSchemaLoaderTest.java
@@ -1,0 +1,17 @@
+package com.cii.messaging.validator;
+
+import org.junit.jupiter.api.Test;
+
+import javax.xml.validation.Schema;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class UneceSchemaLoaderTest {
+
+    @Test
+    void shouldLoadInvoiceSchema() throws Exception {
+        Schema schema = UneceSchemaLoader.loadSchema("CrossIndustryInvoice.xsd");
+        assertNotNull(schema);
+    }
+}
+


### PR DESCRIPTION
## Summary
- load version-specific UNECE XSD schemas via new `UneceSchemaLoader`
- document CLI usage, deployment options and helper scripts

## Testing
- `mvn -pl cii-validator -am test`


------
https://chatgpt.com/codex/tasks/task_e_68c8297da244832ea543349f4216565e