### PR TITLE
Remplacer les références D16B par le namespace 100

### DIFF
--- a/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/invoice/Invoice.java
+++ b/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/invoice/Invoice.java
@@ -7,7 +7,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 /**
  * Dedicated model for invoices based on UNECE CrossIndustryInvoiceType.
  */
-@XmlRootElement(name = "CrossIndustryInvoice", namespace = "urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:16B")
+@XmlRootElement(name = "CrossIndustryInvoice", namespace = "urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100")
 public class Invoice extends CrossIndustryInvoiceType {
     // Additional domain-specific helpers or validations can be added here later.
 }

--- a/cii-messaging-parent/cii-reader/src/test/resources/invoice-invalid-numeric.xml
+++ b/cii-messaging-parent/cii-reader/src/test/resources/invoice-invalid-numeric.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:16B"
-                          xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:16B"
-                          xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:16B">
+<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+                          xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+                          xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
     <rsm:ExchangedDocument>
         <ram:ID>INV-2024-001</ram:ID>
         <ram:TypeCode>380</ram:TypeCode>

--- a/cii-messaging-parent/cii-reader/src/test/resources/invoice-sample.xml
+++ b/cii-messaging-parent/cii-reader/src/test/resources/invoice-sample.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:16B"
-                          xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:16B"
-                          xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:16B">
+<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+                          xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+                          xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
     <rsm:ExchangedDocument>
         <ram:ID>INV-2024-001</ram:ID>
         <ram:TypeCode>380</ram:TypeCode>

--- a/cii-messaging-parent/cii-samples/src/main/resources/samples/invoice-sample.xml
+++ b/cii-messaging-parent/cii-samples/src/main/resources/samples/invoice-sample.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:16B"
-                          xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:16B"
-                          xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:16B">
+<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+                          xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+                          xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
     <rsm:ExchangedDocument>
         <ram:ID>INV-2024-001</ram:ID>
         <ram:TypeCode>380</ram:TypeCode>

--- a/cii-messaging-parent/cii-validator/src/main/java/com/cii/messaging/validator/SchemaVersion.java
+++ b/cii-messaging-parent/cii-validator/src/main/java/com/cii/messaging/validator/SchemaVersion.java
@@ -1,8 +1,8 @@
 package com.cii.messaging.validator;
 
 public enum SchemaVersion {
-    D23B("D23B", "urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:23B"),
-	D24A("D24A", "urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:24A");
+    D23B("D23B", "urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"),
+    D24A("D24A", "urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100");
 
     private final String version;
     private final String namespace;

--- a/cii-messaging-parent/cii-validator/src/main/resources/schematron/D23B.xslt
+++ b/cii-messaging-parent/cii-validator/src/main/resources/schematron/D23B.xslt
@@ -2,8 +2,8 @@
 <xsl:stylesheet version="2.0"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-    xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:26"
-    xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:34">
+    xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+    xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100">
   <xsl:output method="xml" indent="yes"/>
   <xsl:template match="/">
     <svrl:schematron-output>

--- a/cii-messaging-parent/cii-validator/src/main/resources/schematron/D24A.xslt
+++ b/cii-messaging-parent/cii-validator/src/main/resources/schematron/D24A.xslt
@@ -2,8 +2,8 @@
 <xsl:stylesheet version="2.0"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-    xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:16B"
-    xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:16B">
+    xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+    xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100">
   <xsl:output method="xml" indent="yes"/>
   <xsl:template match="/">
     <svrl:schematron-output>

--- a/cii-messaging-parent/cii-validator/src/test/resources/invoice-missing-buyer-ref.xml
+++ b/cii-messaging-parent/cii-validator/src/test/resources/invoice-missing-buyer-ref.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:16B"
-                          xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:16B"
-                          xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:16B">
+<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+                          xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+                          xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
     <rsm:ExchangedDocument>
         <ram:ID>INV-2024-001</ram:ID>
         <ram:TypeCode>380</ram:TypeCode>

--- a/cii-messaging-parent/cii-writer/src/test/resources/invoice-sample.xml
+++ b/cii-messaging-parent/cii-writer/src/test/resources/invoice-sample.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:16B"
-                          xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:16B"
-                          xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:16B">
+<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+                          xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+                          xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
     <rsm:ExchangedDocument>
         <ram:ID>INV-2024-001</ram:ID>
         <ram:TypeCode>380</ram:TypeCode>


### PR DESCRIPTION
## Summary
- remplace les dernières occurrences du namespace CrossIndustryInvoice D16B par la variante officielle `...:100`
- aligne `SchemaVersion` et les ressources Schematron sur les versions D23B/D24A et ajoute l'équivalent D24A
- met à jour tous les échantillons XML utilisés en test pour refléter la nouvelle valeur de namespace

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68c861aa88a8832ebe5fb63baf02cfdf