### PR TITLE
Align order namespaces and harden XML readers

### DIFF
--- a/cii-messaging-parent/README.md
+++ b/cii-messaging-parent/README.md
@@ -1,7 +1,7 @@
 # CII Messaging System
 
 Système Java 21 modulaire pour la lecture, l'écriture et la validation de messages **UN/CEFACT Cross Industry**.
-Il couvre les flux ORDER, ORDERSP, DESADV et INVOICE et reste compatible avec ZUGFeRD, XRechnung et Factur-X.
+Il couvre les flux ORDER, ORDER_RESPONSE, DESPATCH_ADVICE (DESADV) et INVOICE et reste compatible avec ZUGFeRD, XRechnung et Factur-X.
 
 ## 📦 Modules
 
@@ -124,20 +124,11 @@ java -jar cii-cli.jar parse cii-samples/src/main/resources/samples/invoice-sampl
 ```
 
 ```bash
-# Générer une facture (INVOICE) à partir d'une commande
-java -jar cii-cli.jar generate INVOICE \
-  --from-order cii-samples/src/main/resources/samples/order-sample.xml \
-  --output invoice.xml
+# Valider une commande
+java -jar cii-cli.jar validate cii-samples/src/main/resources/samples/order-sample.xml
 
-# Générer un avis d'expédition (DESADV)
-java -jar cii-cli.jar generate DESADV \
-  --from-order cii-samples/src/main/resources/samples/order-sample.xml \
-  --output desadv.xml
-
-# Générer une réponse à commande (ORDERSP)
-java -jar cii-cli.jar generate ORDERSP \
-  --from-order cii-samples/src/main/resources/samples/order-sample.xml \
-  --output ordersp.xml
+# Valider une facture
+java -jar cii-cli.jar validate cii-samples/src/main/resources/samples/invoice-sample.xml
 ```
 
 ## 📑 Schémas XSD

--- a/cii-messaging-parent/cii-cli/src/test/java/com/cii/messaging/cli/ValidateCommandTest.java
+++ b/cii-messaging-parent/cii-cli/src/test/java/com/cii/messaging/cli/ValidateCommandTest.java
@@ -9,7 +9,7 @@ public class ValidateCommandTest {
 
     @Test
     void invalidSampleReturnsError() {
-        String sample = getClass().getResource("/order-sample.xml").getPath();
+        String sample = getClass().getResource("/order-invalid-sample.xml").getPath();
         int exitCode = new CommandLine(new ValidateCommand()).execute(sample);
         assertThat(exitCode).isNotZero();
     }

--- a/cii-messaging-parent/cii-cli/src/test/resources/order-invalid-sample.xml
+++ b/cii-messaging-parent/cii-cli/src/test/resources/order-invalid-sample.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rsm:CrossIndustryOrder xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryOrder:16"
+                        xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:16"
+                        xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:16">
+    <rsm:ExchangedDocument>
+        <ram:ID>ORD-LEGACY-001</ram:ID>
+    </rsm:ExchangedDocument>
+</rsm:CrossIndustryOrder>

--- a/cii-messaging-parent/cii-cli/src/test/resources/order-sample.xml
+++ b/cii-messaging-parent/cii-cli/src/test/resources/order-sample.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rsm:CrossIndustryOrder xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryOrder:16"
-                        xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:16"
-                        xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:16">
+<rsm:CrossIndustryOrder xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryOrder:100"
+                        xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+                        xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
     <rsm:ExchangedDocument>
         <ram:ID>ORD-2024-001</ram:ID>
         <ram:TypeCode>220</ram:TypeCode>

--- a/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/order/Order.java
+++ b/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/order/Order.java
@@ -7,7 +7,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 /**
  * Dedicated model for orders based on UNECE CrossIndustryOrderType.
  */
-@XmlRootElement(name = "CrossIndustryOrder", namespace = "urn:un:unece:uncefact:data:standard:CrossIndustryOrder:16")
+@XmlRootElement(name = "CrossIndustryOrder", namespace = "urn:un:unece:uncefact:data:standard:CrossIndustryOrder:100")
 public class Order extends CrossIndustryOrderType {
     // Additional domain-specific helpers or validations can be added here later.
 }

--- a/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/CIIReaderFactory.java
+++ b/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/CIIReaderFactory.java
@@ -1,122 +1,114 @@
 package com.cii.messaging.reader;
 
-import java.io.InputStream;
-import java.io.StringReader;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * Factory responsible for instantiating the appropriate {@link CIIReader}
  * implementation depending on either the expected {@link MessageType} or the
  * root element of the provided XML content.
  */
-public class CIIReaderFactory {
+public final class CIIReaderFactory {
+
+    private static final Map<MessageType, CIIReader<?>> READERS;
+
+    static {
+        EnumMap<MessageType, CIIReader<?>> readers = new EnumMap<>(MessageType.class);
+        readers.put(MessageType.ORDER, new OrderReader());
+        readers.put(MessageType.INVOICE, new InvoiceReader());
+        readers.put(MessageType.DESPATCH_ADVICE, new DesadvReader());
+        readers.put(MessageType.ORDER_RESPONSE, new OrderResponseReader());
+        READERS = Collections.unmodifiableMap(readers);
+    }
+
+    private CIIReaderFactory() {
+        // Utility class
+    }
 
     public static CIIReader<?> createReader(MessageType messageType) {
-        switch (messageType) {
-            case ORDER:
-                return new OrderReader();
-            case INVOICE:
-                return new InvoiceReader();
-            case DESADV:
-                return new DesadvReader();
-            case ORDERSP:
-                return new OrderResponseReader();
-            default:
-                throw new IllegalArgumentException("Type de message non pris en charge : " + messageType);
+        Objects.requireNonNull(messageType, "messageType");
+        CIIReader<?> reader = READERS.get(messageType);
+        if (reader == null) {
+            throw new IllegalArgumentException("Type de message non pris en charge : " + messageType);
         }
+        return reader;
     }
 
     public static CIIReader<?> createReader(String xmlContent) throws CIIReaderException {
-        XMLInputFactory factory = XMLInputFactory.newFactory();
-        factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
-        factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
-        factory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false);
-
-        XMLStreamReader reader = null;
-        try {
-            reader = factory.createXMLStreamReader(new StringReader(xmlContent));
-            while (reader.hasNext()) {
-                int event = reader.next();
-                if (event == XMLStreamConstants.DTD || event == XMLStreamConstants.ENTITY_REFERENCE) {
-                    throw new CIIReaderException("DOCTYPE non autorisé", new XMLStreamException("DOCTYPE non autorisé"));
-                }
-                if (event == XMLStreamConstants.START_ELEMENT) {
-                    String localName = reader.getLocalName();
-                    switch (localName) {
-                        case "CrossIndustryOrder":
-                            return new OrderReader();
-                        case "CrossIndustryInvoice":
-                            return new InvoiceReader();
-                        case "CrossIndustryDespatchAdvice":
-                            return new DesadvReader();
-                        case "CrossIndustryOrderResponse":
-                            return new OrderResponseReader();
-                        default:
-                            throw new CIIReaderException("Type de message non pris en charge : " + localName);
-                    }
+        Objects.requireNonNull(xmlContent, "xmlContent");
+        XMLInputFactory factory = createSecureXmlInputFactory();
+        try (StringReader contentReader = new StringReader(xmlContent)) {
+            XMLStreamReader xmlReader = factory.createXMLStreamReader(contentReader);
+            try {
+                MessageType messageType = detectMessageType(xmlReader);
+                return createReader(messageType);
+            } finally {
+                try {
+                    xmlReader.close();
+                } catch (XMLStreamException ignored) {
+                    // ignore
                 }
             }
         } catch (XMLStreamException e) {
             throw new CIIReaderException("Contenu XML invalide", e);
-        } finally {
-            if (reader != null) {
-                try {
-                    reader.close();
-                } catch (XMLStreamException e) {
-                    // ignore
-                }
-            }
         }
-        throw new CIIReaderException("Impossible de détecter le type de message à partir du contenu XML");
     }
 
     public static CIIReader<?> createReader(Path xmlFile) throws CIIReaderException {
-        XMLInputFactory factory = XMLInputFactory.newFactory();
-        factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
-        factory.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
-        factory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false);
-
-        XMLStreamReader reader = null;
+        Objects.requireNonNull(xmlFile, "xmlFile");
+        XMLInputFactory factory = createSecureXmlInputFactory();
         try (InputStream inputStream = Files.newInputStream(xmlFile)) {
-            reader = factory.createXMLStreamReader(inputStream);
-            while (reader.hasNext()) {
-                int event = reader.next();
-                if (event == XMLStreamConstants.DTD || event == XMLStreamConstants.ENTITY_REFERENCE) {
-                    throw new CIIReaderException("DOCTYPE non autorisé", new XMLStreamException("DOCTYPE non autorisé"));
-                }
-                if (event == XMLStreamConstants.START_ELEMENT) {
-                    String localName = reader.getLocalName();
-                    switch (localName) {
-                        case "CrossIndustryOrder":
-                            return new OrderReader();
-                        case "CrossIndustryInvoice":
-                            return new InvoiceReader();
-                        case "CrossIndustryDespatchAdvice":
-                            return new DesadvReader();
-                        case "CrossIndustryOrderResponse":
-                            return new OrderResponseReader();
-                        default:
-                            throw new CIIReaderException("Type de message non pris en charge : " + localName);
-                    }
+            XMLStreamReader xmlReader = factory.createXMLStreamReader(inputStream);
+            try {
+                MessageType messageType = detectMessageType(xmlReader);
+                return createReader(messageType);
+            } finally {
+                try {
+                    xmlReader.close();
+                } catch (XMLStreamException ignored) {
+                    // ignore
                 }
             }
         } catch (IOException | XMLStreamException e) {
             throw new CIIReaderException("Fichier XML invalide", e);
-        } finally {
-            if (reader != null) {
+        }
+    }
+
+    private static XMLInputFactory createSecureXmlInputFactory() {
+        XMLInputFactory factory = XMLInputFactory.newFactory();
+        factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+        factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+        factory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false);
+        return factory;
+    }
+
+    private static MessageType detectMessageType(XMLStreamReader reader) throws XMLStreamException, CIIReaderException {
+        while (reader.hasNext()) {
+            int event = reader.next();
+            if (event == XMLStreamConstants.DTD || event == XMLStreamConstants.ENTITY_REFERENCE) {
+                throw new CIIReaderException("DOCTYPE non autorisé", new XMLStreamException("DOCTYPE non autorisé"));
+            }
+            if (event == XMLStreamConstants.START_ELEMENT) {
+                String localName = reader.getLocalName();
+                String namespace = reader.getNamespaceURI();
                 try {
-                    reader.close();
-                } catch (XMLStreamException e) {
-                    // ignore
+                    return MessageType.fromRootElement(localName, namespace);
+                } catch (IllegalArgumentException ex) {
+                    throw new CIIReaderException(ex.getMessage(), ex);
                 }
             }
         }
-        throw new CIIReaderException("Impossible de détecter le type de message à partir du fichier XML");
+        throw new CIIReaderException("Impossible de détecter le type de message à partir du contenu XML");
     }
 }

--- a/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/CIIReaderFactory.java
+++ b/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/CIIReaderFactory.java
@@ -103,7 +103,10 @@ public final class CIIReaderFactory {
                 String localName = reader.getLocalName();
                 String namespace = reader.getNamespaceURI();
                 try {
-                    return MessageType.fromRootElement(localName, namespace);
+                    if (namespace != null && !namespace.isBlank()) {
+                        return MessageType.fromRootElement(localName, namespace);
+                    }
+                    return MessageType.fromRootElement(localName);
                 } catch (IllegalArgumentException ex) {
                     throw new CIIReaderException(ex.getMessage(), ex);
                 }

--- a/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/DesadvReader.java
+++ b/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/DesadvReader.java
@@ -1,56 +1,13 @@
 package com.cii.messaging.reader;
 
 import com.cii.messaging.model.despatchadvice.DespatchAdvice;
-import jakarta.xml.bind.JAXBContext;
-import jakarta.xml.bind.JAXBException;
-import jakarta.xml.bind.Unmarshaller;
-
-import java.io.File;
-import java.io.InputStream;
-import java.io.StringReader;
 
 /**
  * JAXB based reader for CrossIndustryDespatchAdvice documents.
  */
-public class DesadvReader implements CIIReader<DespatchAdvice> {
-
-    private final JAXBContext context;
+public class DesadvReader extends JaxbReader<DespatchAdvice> {
 
     public DesadvReader() {
-        try {
-            this.context = JAXBContext.newInstance(DespatchAdvice.class);
-        } catch (JAXBException e) {
-            throw new RuntimeException("Échec de l'initialisation du contexte JAXB", e);
-        }
-    }
-
-    @Override
-    public DespatchAdvice read(File xmlFile) throws CIIReaderException {
-        try {
-            Unmarshaller unmarshaller = context.createUnmarshaller();
-            return (DespatchAdvice) unmarshaller.unmarshal(xmlFile);
-        } catch (JAXBException e) {
-            throw new CIIReaderException("Échec de l'analyse du fichier XML : " + xmlFile.getName(), e);
-        }
-    }
-
-    @Override
-    public DespatchAdvice read(InputStream inputStream) throws CIIReaderException {
-        try {
-            Unmarshaller unmarshaller = context.createUnmarshaller();
-            return (DespatchAdvice) unmarshaller.unmarshal(inputStream);
-        } catch (JAXBException e) {
-            throw new CIIReaderException("Échec de l'analyse du XML depuis le flux d'entrée", e);
-        }
-    }
-
-    @Override
-    public DespatchAdvice read(String xmlContent) throws CIIReaderException {
-        try {
-            Unmarshaller unmarshaller = context.createUnmarshaller();
-            return (DespatchAdvice) unmarshaller.unmarshal(new StringReader(xmlContent));
-        } catch (JAXBException e) {
-            throw new CIIReaderException("Échec de l'analyse du contenu XML", e);
-        }
+        super(DespatchAdvice.class);
     }
 }

--- a/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/InvoiceReader.java
+++ b/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/InvoiceReader.java
@@ -1,56 +1,13 @@
 package com.cii.messaging.reader;
 
 import com.cii.messaging.model.invoice.Invoice;
-import jakarta.xml.bind.JAXBContext;
-import jakarta.xml.bind.JAXBException;
-import jakarta.xml.bind.Unmarshaller;
-
-import java.io.File;
-import java.io.InputStream;
-import java.io.StringReader;
 
 /**
  * JAXB based reader for CrossIndustryInvoice documents.
  */
-public class InvoiceReader implements CIIReader<Invoice> {
-
-    private final JAXBContext context;
+public class InvoiceReader extends JaxbReader<Invoice> {
 
     public InvoiceReader() {
-        try {
-            this.context = JAXBContext.newInstance(Invoice.class);
-        } catch (JAXBException e) {
-            throw new RuntimeException("Échec de l'initialisation du contexte JAXB", e);
-        }
-    }
-
-    @Override
-    public Invoice read(File xmlFile) throws CIIReaderException {
-        try {
-            Unmarshaller unmarshaller = context.createUnmarshaller();
-            return (Invoice) unmarshaller.unmarshal(xmlFile);
-        } catch (JAXBException e) {
-            throw new CIIReaderException("Échec de l'analyse du fichier XML : " + xmlFile.getName(), e);
-        }
-    }
-
-    @Override
-    public Invoice read(InputStream inputStream) throws CIIReaderException {
-        try {
-            Unmarshaller unmarshaller = context.createUnmarshaller();
-            return (Invoice) unmarshaller.unmarshal(inputStream);
-        } catch (JAXBException e) {
-            throw new CIIReaderException("Échec de l'analyse du XML depuis le flux d'entrée", e);
-        }
-    }
-
-    @Override
-    public Invoice read(String xmlContent) throws CIIReaderException {
-        try {
-            Unmarshaller unmarshaller = context.createUnmarshaller();
-            return (Invoice) unmarshaller.unmarshal(new StringReader(xmlContent));
-        } catch (JAXBException e) {
-            throw new CIIReaderException("Échec de l'analyse du contenu XML", e);
-        }
+        super(Invoice.class);
     }
 }

--- a/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/JaxbReader.java
+++ b/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/JaxbReader.java
@@ -1,0 +1,103 @@
+package com.cii.messaging.reader;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+/**
+ * Generic JAXB-based implementation of {@link CIIReader}.
+ *
+ * @param <T> message model type
+ */
+public abstract class JaxbReader<T> implements CIIReader<T> {
+
+    private final Class<T> type;
+    private final JAXBContext context;
+
+    protected JaxbReader(Class<T> type) {
+        this.type = type;
+        try {
+            this.context = JAXBContext.newInstance(type);
+        } catch (JAXBException e) {
+            throw new IllegalStateException("Échec de l'initialisation du contexte JAXB", e);
+        }
+    }
+
+    @Override
+    public T read(File xmlFile) throws CIIReaderException {
+        try (InputStream inputStream = Files.newInputStream(xmlFile.toPath())) {
+            byte[] data = inputStream.readAllBytes();
+            return readFromByteArray(data, "Échec de l'analyse du fichier XML : " + xmlFile.getName());
+        } catch (IOException e) {
+            throw new CIIReaderException("Échec de l'analyse du fichier XML : " + xmlFile.getName(), e);
+        }
+    }
+
+    @Override
+    public T read(InputStream inputStream) throws CIIReaderException {
+        try {
+            byte[] data = inputStream.readAllBytes();
+            return readFromByteArray(data, "Échec de l'analyse du XML depuis le flux d'entrée");
+        } catch (IOException e) {
+            throw new CIIReaderException("Échec de l'analyse du XML depuis le flux d'entrée", e);
+        }
+    }
+
+    @Override
+    public T read(String xmlContent) throws CIIReaderException {
+        byte[] data = xmlContent.getBytes(StandardCharsets.UTF_8);
+        return readFromByteArray(data, "Échec de l'analyse du contenu XML");
+    }
+
+    private T readFromByteArray(byte[] data, String errorMessage) throws CIIReaderException {
+        XMLInputFactory factory = createSecureXmlInputFactory();
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(data);
+        return unmarshal(unmarshaller -> {
+            XMLStreamReader xmlReader = factory.createXMLStreamReader(inputStream);
+            try {
+                return unmarshaller.unmarshal(xmlReader);
+            } finally {
+                xmlReader.close();
+            }
+        }, errorMessage);
+    }
+
+    private T unmarshal(UnmarshalOperation operation, String errorMessage) throws CIIReaderException {
+        try {
+            Unmarshaller unmarshaller = context.createUnmarshaller();
+            Object result = operation.unmarshal(unmarshaller);
+            return type.cast(result);
+        } catch (ClassCastException e) {
+            throw new CIIReaderException("Le contenu XML ne correspond pas au type attendu " + type.getSimpleName(), e);
+        } catch (JAXBException e) {
+            throw new CIIReaderException(errorMessage, e);
+        } catch (Exception e) {
+            throw new CIIReaderException(errorMessage, e);
+        }
+    }
+
+    private static XMLInputFactory createSecureXmlInputFactory() {
+        XMLInputFactory factory = XMLInputFactory.newFactory();
+        factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+        factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+        factory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false);
+        factory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, true);
+        return factory;
+    }
+
+    @FunctionalInterface
+    private interface UnmarshalOperation {
+        Object unmarshal(Unmarshaller unmarshaller) throws Exception;
+    }
+}

--- a/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/MessageType.java
+++ b/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/MessageType.java
@@ -24,8 +24,8 @@ public enum MessageType {
     private final Set<String> supportedNamespaces;
 
     MessageType(String rootElement, String namespace) {
-        this.rootElement = rootElement;
-        this.supportedNamespaces = Set.of(namespace);
+        this.rootElement = Objects.requireNonNull(rootElement, "rootElement");
+        this.supportedNamespaces = Set.of(Objects.requireNonNull(namespace, "namespace").trim());
     }
 
     public String getRootElement() {
@@ -51,13 +51,13 @@ public enum MessageType {
         if (messageType == null) {
             throw new IllegalArgumentException("Type de message non pris en charge : " + rootElement);
         }
+
         String sanitizedNamespace = namespaceUri == null ? "" : namespaceUri.trim();
-        if (!messageType.supportsNamespace(sanitizedNamespace)) {
-            String actual = sanitizedNamespace.isEmpty() ? "<non défini>" : sanitizedNamespace;
+        if (!sanitizedNamespace.isEmpty() && !messageType.supportsNamespace(sanitizedNamespace)) {
             throw new IllegalArgumentException(String.format(
                     "Espace de noms inattendu pour %s : %s (attendu %s)",
                     rootElement,
-                    actual,
+                    sanitizedNamespace,
                     messageType.describeSupportedNamespaces()));
         }
         return messageType;

--- a/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/OrderReader.java
+++ b/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/OrderReader.java
@@ -1,56 +1,13 @@
 package com.cii.messaging.reader;
 
 import com.cii.messaging.model.order.Order;
-import jakarta.xml.bind.JAXBContext;
-import jakarta.xml.bind.JAXBException;
-import jakarta.xml.bind.Unmarshaller;
-
-import java.io.File;
-import java.io.InputStream;
-import java.io.StringReader;
 
 /**
  * JAXB based reader for CrossIndustryOrder documents.
  */
-public class OrderReader implements CIIReader<Order> {
-
-    private final JAXBContext context;
+public class OrderReader extends JaxbReader<Order> {
 
     public OrderReader() {
-        try {
-            this.context = JAXBContext.newInstance(Order.class);
-        } catch (JAXBException e) {
-            throw new RuntimeException("Échec de l'initialisation du contexte JAXB", e);
-        }
-    }
-
-    @Override
-    public Order read(File xmlFile) throws CIIReaderException {
-        try {
-            Unmarshaller unmarshaller = context.createUnmarshaller();
-            return (Order) unmarshaller.unmarshal(xmlFile);
-        } catch (JAXBException e) {
-            throw new CIIReaderException("Échec de l'analyse du fichier XML : " + xmlFile.getName(), e);
-        }
-    }
-
-    @Override
-    public Order read(InputStream inputStream) throws CIIReaderException {
-        try {
-            Unmarshaller unmarshaller = context.createUnmarshaller();
-            return (Order) unmarshaller.unmarshal(inputStream);
-        } catch (JAXBException e) {
-            throw new CIIReaderException("Échec de l'analyse du XML depuis le flux d'entrée", e);
-        }
-    }
-
-    @Override
-    public Order read(String xmlContent) throws CIIReaderException {
-        try {
-            Unmarshaller unmarshaller = context.createUnmarshaller();
-            return (Order) unmarshaller.unmarshal(new StringReader(xmlContent));
-        } catch (JAXBException e) {
-            throw new CIIReaderException("Échec de l'analyse du contenu XML", e);
-        }
+        super(Order.class);
     }
 }

--- a/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/OrderResponseReader.java
+++ b/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/OrderResponseReader.java
@@ -1,56 +1,13 @@
 package com.cii.messaging.reader;
 
 import com.cii.messaging.model.orderresponse.OrderResponse;
-import jakarta.xml.bind.JAXBContext;
-import jakarta.xml.bind.JAXBException;
-import jakarta.xml.bind.Unmarshaller;
-
-import java.io.File;
-import java.io.InputStream;
-import java.io.StringReader;
 
 /**
  * JAXB based reader for CrossIndustryOrderResponse documents.
  */
-public class OrderResponseReader implements CIIReader<OrderResponse> {
-
-    private final JAXBContext context;
+public class OrderResponseReader extends JaxbReader<OrderResponse> {
 
     public OrderResponseReader() {
-        try {
-            this.context = JAXBContext.newInstance(OrderResponse.class);
-        } catch (JAXBException e) {
-            throw new RuntimeException("Échec de l'initialisation du contexte JAXB", e);
-        }
-    }
-
-    @Override
-    public OrderResponse read(File xmlFile) throws CIIReaderException {
-        try {
-            Unmarshaller unmarshaller = context.createUnmarshaller();
-            return (OrderResponse) unmarshaller.unmarshal(xmlFile);
-        } catch (JAXBException e) {
-            throw new CIIReaderException("Échec de l'analyse du fichier XML : " + xmlFile.getName(), e);
-        }
-    }
-
-    @Override
-    public OrderResponse read(InputStream inputStream) throws CIIReaderException {
-        try {
-            Unmarshaller unmarshaller = context.createUnmarshaller();
-            return (OrderResponse) unmarshaller.unmarshal(inputStream);
-        } catch (JAXBException e) {
-            throw new CIIReaderException("Échec de l'analyse du XML depuis le flux d'entrée", e);
-        }
-    }
-
-    @Override
-    public OrderResponse read(String xmlContent) throws CIIReaderException {
-        try {
-            Unmarshaller unmarshaller = context.createUnmarshaller();
-            return (OrderResponse) unmarshaller.unmarshal(new StringReader(xmlContent));
-        } catch (JAXBException e) {
-            throw new CIIReaderException("Échec de l'analyse du contenu XML", e);
-        }
+        super(OrderResponse.class);
     }
 }

--- a/cii-messaging-parent/cii-reader/src/test/resources/order-sample.xml
+++ b/cii-messaging-parent/cii-reader/src/test/resources/order-sample.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rsm:CrossIndustryOrder xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryOrder:16"
-                        xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:16"
-                        xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:16">
+<rsm:CrossIndustryOrder xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryOrder:100"
+                        xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+                        xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
     <rsm:ExchangedDocument>
         <ram:ID>ORD-2024-001</ram:ID>
         <ram:TypeCode>220</ram:TypeCode>

--- a/cii-messaging-parent/cii-reader/src/test/resources/order-with-header.xml
+++ b/cii-messaging-parent/cii-reader/src/test/resources/order-with-header.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rsm:CrossIndustryOrder xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryOrder:16"
-                        xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:16"
-                        xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:16">
+<rsm:CrossIndustryOrder xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryOrder:100"
+                        xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+                        xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
     <rsm:ExchangedDocument>
         <ram:ID>ORD-2024-001</ram:ID>
         <ram:TypeCode>220</ram:TypeCode>

--- a/cii-messaging-parent/cii-samples/src/main/resources/samples/order-sample.xml
+++ b/cii-messaging-parent/cii-samples/src/main/resources/samples/order-sample.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rsm:CrossIndustryOrder xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryOrder:16"
-                        xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:16"
-                        xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:16">
+<rsm:CrossIndustryOrder xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryOrder:100"
+                        xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+                        xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
     <rsm:ExchangedDocument>
         <ram:ID>ORD-2024-001</ram:ID>
         <ram:TypeCode>220</ram:TypeCode>

--- a/cii-messaging-parent/cii-validator/src/main/java/com/cii/messaging/validator/MessageType.java
+++ b/cii-messaging-parent/cii-validator/src/main/java/com/cii/messaging/validator/MessageType.java
@@ -1,11 +1,65 @@
 package com.cii.messaging.validator;
 
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
 /**
  * Supported CII message types for validation.
  */
 public enum MessageType {
-    INVOICE,
-    DESADV,
-    ORDER,
-    ORDERSP
+    INVOICE("CrossIndustryInvoice", "urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"),
+    DESPATCH_ADVICE("CrossIndustryDespatchAdvice", "urn:un:unece:uncefact:data:standard:CrossIndustryDespatchAdvice:100"),
+    ORDER("CrossIndustryOrder", "urn:un:unece:uncefact:data:standard:CrossIndustryOrder:100"),
+    ORDER_RESPONSE("CrossIndustryOrderResponse", "urn:un:unece:uncefact:data:standard:CrossIndustryOrderResponse:100");
+
+    private static final Map<String, MessageType> BY_ROOT_ELEMENT = Map.of(
+            INVOICE.rootElement, INVOICE,
+            DESPATCH_ADVICE.rootElement, DESPATCH_ADVICE,
+            ORDER.rootElement, ORDER,
+            ORDER_RESPONSE.rootElement, ORDER_RESPONSE
+    );
+
+    private final String rootElement;
+    private final Set<String> supportedNamespaces;
+
+    MessageType(String rootElement, String namespace) {
+        this.rootElement = rootElement;
+        this.supportedNamespaces = Set.of(namespace);
+    }
+
+    public String getRootElement() {
+        return rootElement;
+    }
+
+    public boolean supportsNamespace(String namespaceUri) {
+        String candidate = namespaceUri == null ? "" : namespaceUri.trim();
+        return supportedNamespaces.contains(candidate);
+    }
+
+    public String describeSupportedNamespaces() {
+        return String.join(", ", supportedNamespaces);
+    }
+
+    public static MessageType fromRootElement(String rootElement) {
+        return fromRootElement(rootElement, null);
+    }
+
+    public static MessageType fromRootElement(String rootElement, String namespaceUri) {
+        Objects.requireNonNull(rootElement, "rootElement");
+        MessageType messageType = BY_ROOT_ELEMENT.get(rootElement);
+        if (messageType == null) {
+            throw new IllegalArgumentException("Type de message non pris en charge : " + rootElement);
+        }
+        String sanitizedNamespace = namespaceUri == null ? "" : namespaceUri.trim();
+        if (!messageType.supportsNamespace(sanitizedNamespace)) {
+            String actual = sanitizedNamespace.isEmpty() ? "<non défini>" : sanitizedNamespace;
+            throw new IllegalArgumentException(String.format(
+                    "Espace de noms inattendu pour %s : %s (attendu %s)",
+                    rootElement,
+                    actual,
+                    messageType.describeSupportedNamespaces()));
+        }
+        return messageType;
+    }
 }

--- a/cii-messaging-parent/cii-validator/src/main/java/com/cii/messaging/validator/MessageType.java
+++ b/cii-messaging-parent/cii-validator/src/main/java/com/cii/messaging/validator/MessageType.java
@@ -24,8 +24,8 @@ public enum MessageType {
     private final Set<String> supportedNamespaces;
 
     MessageType(String rootElement, String namespace) {
-        this.rootElement = rootElement;
-        this.supportedNamespaces = Set.of(namespace);
+        this.rootElement = Objects.requireNonNull(rootElement, "rootElement");
+        this.supportedNamespaces = Set.of(Objects.requireNonNull(namespace, "namespace").trim());
     }
 
     public String getRootElement() {
@@ -51,13 +51,13 @@ public enum MessageType {
         if (messageType == null) {
             throw new IllegalArgumentException("Type de message non pris en charge : " + rootElement);
         }
+
         String sanitizedNamespace = namespaceUri == null ? "" : namespaceUri.trim();
-        if (!messageType.supportsNamespace(sanitizedNamespace)) {
-            String actual = sanitizedNamespace.isEmpty() ? "<non défini>" : sanitizedNamespace;
+        if (!sanitizedNamespace.isEmpty() && !messageType.supportsNamespace(sanitizedNamespace)) {
             throw new IllegalArgumentException(String.format(
                     "Espace de noms inattendu pour %s : %s (attendu %s)",
                     rootElement,
-                    actual,
+                    sanitizedNamespace,
                     messageType.describeSupportedNamespaces()));
         }
         return messageType;

--- a/cii-messaging-parent/cii-validator/src/main/java/com/cii/messaging/validator/SchemaVersion.java
+++ b/cii-messaging-parent/cii-validator/src/main/java/com/cii/messaging/validator/SchemaVersion.java
@@ -1,23 +1,25 @@
 package com.cii.messaging.validator;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
 public enum SchemaVersion {
-    D23B("D23B", "urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"),
-    D24A("D24A", "urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100");
+    D23B("D23B"),
+    D24A("D24A");
+
+    private static final String PROPERTY_KEY = "unece.version";
+    private static final String ENVIRONMENT_KEY = "UNECE_VERSION";
+    private static final String VERSION_RESOURCE = "unece-version.properties";
 
     private final String version;
-    private final String namespace;
 
-    SchemaVersion(String version, String namespace) {
+    SchemaVersion(String version) {
         this.version = version;
-        this.namespace = namespace;
     }
 
     public String getVersion() {
         return version;
-    }
-
-    public String getNamespace() {
-        return namespace;
     }
 
     public static SchemaVersion fromString(String version) {
@@ -30,7 +32,34 @@ public enum SchemaVersion {
     }
 
     public static SchemaVersion getDefault() {
-        String v = System.getProperty("unece.version", "D23B");
-        return fromString(v);
+        String configuredVersion = resolveConfiguredVersion();
+        return fromString(configuredVersion);
+    }
+
+    private static String resolveConfiguredVersion() {
+        String configuredVersion = System.getProperty(PROPERTY_KEY);
+        if (configuredVersion == null || configuredVersion.isBlank()) {
+            configuredVersion = System.getenv(ENVIRONMENT_KEY);
+        }
+        if (configuredVersion == null || configuredVersion.isBlank()) {
+            configuredVersion = readVersionFromResource();
+        }
+        if (configuredVersion == null || configuredVersion.isBlank()) {
+            configuredVersion = D23B.version;
+        }
+        return configuredVersion.trim();
+    }
+
+    private static String readVersionFromResource() {
+        try (InputStream inputStream = SchemaVersion.class.getClassLoader().getResourceAsStream(VERSION_RESOURCE)) {
+            if (inputStream == null) {
+                return null;
+            }
+            Properties properties = new Properties();
+            properties.load(inputStream);
+            return properties.getProperty(PROPERTY_KEY);
+        } catch (IOException e) {
+            return null;
+        }
     }
 }

--- a/cii-messaging-parent/cii-validator/src/main/java/com/cii/messaging/validator/SchemaVersion.java
+++ b/cii-messaging-parent/cii-validator/src/main/java/com/cii/messaging/validator/SchemaVersion.java
@@ -5,21 +5,27 @@ import java.io.InputStream;
 import java.util.Properties;
 
 public enum SchemaVersion {
-    D23B("D23B"),
-    D24A("D24A");
+    D23B("D23B", "urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"),
+    D24A("D24A", "urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100");
 
     private static final String PROPERTY_KEY = "unece.version";
     private static final String ENVIRONMENT_KEY = "UNECE_VERSION";
     private static final String VERSION_RESOURCE = "unece-version.properties";
 
     private final String version;
+    private final String namespace;
 
-    SchemaVersion(String version) {
+    SchemaVersion(String version, String namespace) {
         this.version = version;
+        this.namespace = namespace;
     }
 
     public String getVersion() {
         return version;
+    }
+
+    public String getNamespace() {
+        return namespace;
     }
 
     public static SchemaVersion fromString(String version) {

--- a/cii-messaging-parent/cii-validator/src/main/java/com/cii/messaging/validator/UneceSchemaLoader.java
+++ b/cii-messaging-parent/cii-validator/src/main/java/com/cii/messaging/validator/UneceSchemaLoader.java
@@ -8,8 +8,11 @@ import javax.xml.validation.SchemaFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.Objects;
 
 import org.xml.sax.SAXException;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
 
 /**
  * Utility class to load UNECE XSD schemas according to the configured version.
@@ -33,9 +36,16 @@ public final class UneceSchemaLoader {
      * @throws SAXException  if the XSD cannot be parsed
      */
     public static Schema loadSchema(String xsdName) throws IOException, SAXException {
-        String version = SchemaVersion.getDefault().getVersion();
+        return loadSchema(xsdName, SchemaVersion.getDefault());
+    }
+
+    public static Schema loadSchema(String xsdName, SchemaVersion version) throws IOException, SAXException {
+        Objects.requireNonNull(xsdName, "xsdName");
+        Objects.requireNonNull(version, "version");
+
+        String uneceVersion = version.getVersion();
         String baseName = xsdName.endsWith(".xsd") ? xsdName.substring(0, xsdName.length() - 4) : xsdName;
-        String resourcePath = String.format("/xsd/%s/%s_100p%s.xsd", version, baseName, version);
+        String resourcePath = String.format("/xsd/%s/%s_100p%s.xsd", uneceVersion, baseName, uneceVersion);
 
         URL url = UneceSchemaLoader.class.getResource(resourcePath);
         if (url == null) {
@@ -44,8 +54,19 @@ public final class UneceSchemaLoader {
 
         try (InputStream is = url.openStream()) {
             SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+            disableExternalAccess(factory);
             StreamSource source = new StreamSource(is, url.toExternalForm());
             return factory.newSchema(source);
+        }
+    }
+
+    private static void disableExternalAccess(SchemaFactory factory) {
+        try {
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        } catch (SAXNotRecognizedException | SAXNotSupportedException ex) {
+            // Certains parseurs ne supportent pas ces propriétés : on ignore silencieusement.
         }
     }
 }

--- a/cii-messaging-parent/cii-validator/src/main/java/com/cii/messaging/validator/UneceSchemaLoader.java
+++ b/cii-messaging-parent/cii-validator/src/main/java/com/cii/messaging/validator/UneceSchemaLoader.java
@@ -70,4 +70,3 @@ public final class UneceSchemaLoader {
         }
     }
 }
-

--- a/cii-messaging-parent/cii-validator/src/main/java/com/cii/messaging/validator/impl/CompositeValidator.java
+++ b/cii-messaging-parent/cii-validator/src/main/java/com/cii/messaging/validator/impl/CompositeValidator.java
@@ -20,10 +20,12 @@ public class CompositeValidator implements CIIValidator {
     public CompositeValidator() {
         validators.add(new XSDValidator());
         validators.add(new SchematronValidator());
+        validators.forEach(v -> v.setSchemaVersion(schemaVersion));
     }
-    
+
     public void addValidator(CIIValidator validator) {
         validators.add(validator);
+        validator.setSchemaVersion(schemaVersion);
     }
     
     @Override
@@ -47,10 +49,7 @@ public class CompositeValidator implements CIIValidator {
             allErrors.addAll(result.getErrors());
             allWarnings.addAll(result.getWarnings());
             
-            if (validatedAgainst.length() > 0) {
-                validatedAgainst.append(", ");
-            }
-            validatedAgainst.append(result.getValidatedAgainst());
+            appendValidatedAgainst(validatedAgainst, result);
         }
         
         combinedResult.errors(allErrors);
@@ -112,10 +111,7 @@ public class CompositeValidator implements CIIValidator {
             allErrors.addAll(result.getErrors());
             allWarnings.addAll(result.getWarnings());
 
-            if (validatedAgainst.length() > 0) {
-                validatedAgainst.append(", ");
-            }
-            validatedAgainst.append(result.getValidatedAgainst());
+            appendValidatedAgainst(validatedAgainst, result);
         }
 
         combinedResult.errors(allErrors);
@@ -124,5 +120,15 @@ public class CompositeValidator implements CIIValidator {
         combinedResult.validationTimeMs(System.currentTimeMillis() - start);
 
         return combinedResult.build();
+    }
+
+    private static void appendValidatedAgainst(StringBuilder target, ValidationResult result) {
+        String validatorName = result.getValidatedAgainst();
+        if (validatorName != null && !validatorName.isBlank()) {
+            if (target.length() > 0) {
+                target.append(", ");
+            }
+            target.append(validatorName);
+        }
     }
 }

--- a/cii-messaging-parent/cii-validator/src/main/java/com/cii/messaging/validator/impl/XSDValidator.java
+++ b/cii-messaging-parent/cii-validator/src/main/java/com/cii/messaging/validator/impl/XSDValidator.java
@@ -1,7 +1,6 @@
 package com.cii.messaging.validator.impl;
 
 import com.cii.messaging.validator.*;
-import com.cii.messaging.validator.MessageType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -12,41 +11,39 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.Source;
-import javax.xml.transform.stream.StreamSource;
 import javax.xml.transform.sax.SAXSource;
 import javax.xml.validation.Schema;
-import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Validator de messages CII basé exclusivement sur les schémas XSD D23B.
+ * Validator de messages CII basé sur les schémas XSD officiels UN/CEFACT.
  * <p>
- * Cette implémentation charge les schémas officiels UN/CEFACT pour la version
- * D23B et exécute une validation XSD stricte pour chaque type de message
- * supporté. Aucune autre version n'est autorisée.
+ * Les schémas sont chargés dynamiquement selon la version configurée via
+ * {@link SchemaVersion}.
  * </p>
  */
 public class XSDValidator implements CIIValidator {
     private static final Logger logger = LoggerFactory.getLogger(XSDValidator.class);
-    private static final SchemaVersion SCHEMA_VERSION = SchemaVersion.D23B;
-
-    private final Map<MessageType, Schema> schemaCache = new ConcurrentHashMap<>();
+    private final Map<SchemaCacheKey, Schema> schemaCache = new ConcurrentHashMap<>();
+    private volatile SchemaVersion schemaVersion = SchemaVersion.getDefault();
 
     @Override
     public ValidationResult validate(File xmlFile) {
         long start = System.currentTimeMillis();
         ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
 
+        SchemaVersion currentVersion = this.schemaVersion;
         try (InputStream is = new FileInputStream(xmlFile)) {
             byte[] data = is.readAllBytes();
             MessageType type = detectMessageType(data);
-            return performValidation(new ByteArrayInputStream(data), builder, start, type);
+            return performValidation(new ByteArrayInputStream(data), builder, start, type, currentVersion);
         } catch (Exception e) {
             builder.valid(false);
             builder.validationTimeMs(System.currentTimeMillis() - start);
@@ -64,10 +61,11 @@ public class XSDValidator implements CIIValidator {
         long start = System.currentTimeMillis();
         ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
 
+        SchemaVersion currentVersion = this.schemaVersion;
         try {
             byte[] data = inputStream.readAllBytes();
             MessageType type = detectMessageType(data);
-            return performValidation(new ByteArrayInputStream(data), builder, start, type);
+            return performValidation(new ByteArrayInputStream(data), builder, start, type, currentVersion);
         } catch (Exception e) {
             builder.valid(false);
             builder.validationTimeMs(System.currentTimeMillis() - start);
@@ -85,26 +83,22 @@ public class XSDValidator implements CIIValidator {
         return validate(new ByteArrayInputStream(xmlContent.getBytes(StandardCharsets.UTF_8)));
     }
 
-    /**
-     * Seule la version D23B est supportée. Toute autre valeur provoque une
-     * {@link IllegalArgumentException}.
-     */
     @Override
     public void setSchemaVersion(SchemaVersion version) {
-        if (version != SCHEMA_VERSION) {
-            throw new IllegalArgumentException("Seule la version D23B est supportée");
-        }
+        this.schemaVersion = Objects.requireNonNull(version, "version");
+        schemaCache.clear();
     }
 
     private ValidationResult performValidation(InputStream inputStream,
                                                ValidationResult.ValidationResultBuilder builder,
                                                long start,
-                                               MessageType type) {
+                                               MessageType type,
+                                               SchemaVersion version) {
         List<ValidationError> errors = new ArrayList<>();
         List<ValidationWarning> warnings = new ArrayList<>();
 
         try {
-            Schema schema = getSchema(type);
+            Schema schema = getSchema(type, version);
             Validator validator = schema.newValidator();
             ValidationErrorHandler handler = new ValidationErrorHandler(errors, warnings);
             validator.setErrorHandler(handler);
@@ -123,7 +117,7 @@ public class XSDValidator implements CIIValidator {
             builder.valid(!handler.hasErrors());
             builder.errors(errors);
             builder.warnings(warnings);
-            builder.validatedAgainst("XSD " + SCHEMA_VERSION.getVersion());
+            builder.validatedAgainst("XSD " + version.getVersion());
             builder.validationTimeMs(System.currentTimeMillis() - start);
             return builder.build();
         } catch (Exception e) {
@@ -137,42 +131,36 @@ public class XSDValidator implements CIIValidator {
             errors.add(error);
             builder.errors(errors);
             builder.warnings(warnings);
-            builder.validatedAgainst("XSD " + SCHEMA_VERSION.getVersion());
+            builder.validatedAgainst("XSD " + version.getVersion());
             return builder.build();
         }
     }
 
-    private Schema getSchema(MessageType type) throws SAXException, IOException {
-        Schema cached = schemaCache.get(type);
+    private Schema getSchema(MessageType type, SchemaVersion version) throws SAXException, IOException {
+        SchemaCacheKey cacheKey = new SchemaCacheKey(type, version);
+        Schema cached = schemaCache.get(cacheKey);
         if (cached != null) {
             return cached;
         }
 
-        String resource;
-        switch (type) {
-            case INVOICE -> resource = "xsd/CrossIndustryInvoice.xsd";
-            case DESADV -> resource = "xsd/CrossIndustryDespatchAdvice.xsd";
-            case ORDER -> resource = "xsd/CrossIndustryOrder.xsd";
-            case ORDERSP -> resource = "xsd/CrossIndustryOrderResponse.xsd";
-            default -> throw new IllegalArgumentException("Type de message non pris en charge : " + type);
-        }
+        String xsdName = switch (type) {
+            case INVOICE -> "CrossIndustryInvoice.xsd";
+            case DESPATCH_ADVICE -> "CrossIndustryDespatchAdvice.xsd";
+            case ORDER -> "CrossIndustryOrder.xsd";
+            case ORDER_RESPONSE -> "CrossIndustryOrderResponse.xsd";
+        };
 
-        Schema schema;
-        try (InputStream is = getClass().getClassLoader().getResourceAsStream(resource)) {
-            if (is == null) {
-                schema = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI).newSchema();
-            } else {
-                schema = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
-                        .newSchema(new StreamSource(is));
-            }
-        }
-        Schema existing = schemaCache.putIfAbsent(type, schema);
+        Schema schema = UneceSchemaLoader.loadSchema(xsdName, version);
+        Schema existing = schemaCache.putIfAbsent(cacheKey, schema);
         return existing != null ? existing : schema;
     }
 
     private MessageType detectMessageType(byte[] data) throws Exception {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         factory.setNamespaceAware(true);
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
         factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
@@ -181,20 +169,16 @@ public class XSDValidator implements CIIValidator {
         try (ByteArrayInputStream bais = new ByteArrayInputStream(data)) {
             Document doc = builder.parse(bais);
             String root = doc.getDocumentElement().getLocalName();
-            switch (root) {
-                case "CrossIndustryInvoice":
-                    return MessageType.INVOICE;
-                case "CrossIndustryDespatchAdvice":
-                    return MessageType.DESADV;
-                case "CrossIndustryOrder":
-                    return MessageType.ORDER;
-                case "CrossIndustryOrderResponse":
-                    return MessageType.ORDERSP;
-                default:
-                    throw new SAXException("Élément racine inconnu : " + root);
+            String namespace = doc.getDocumentElement().getNamespaceURI();
+            try {
+                return MessageType.fromRootElement(root, namespace);
+            } catch (IllegalArgumentException ex) {
+                throw new SAXException(ex.getMessage(), ex);
             }
         }
     }
+
+    private record SchemaCacheKey(MessageType type, SchemaVersion version) { }
 
     private static class ValidationErrorHandler implements ErrorHandler {
         private final List<ValidationError> errors;

--- a/cii-messaging-parent/cii-validator/src/main/java/com/cii/messaging/validator/impl/XSDValidator.java
+++ b/cii-messaging-parent/cii-validator/src/main/java/com/cii/messaging/validator/impl/XSDValidator.java
@@ -171,7 +171,10 @@ public class XSDValidator implements CIIValidator {
             String root = doc.getDocumentElement().getLocalName();
             String namespace = doc.getDocumentElement().getNamespaceURI();
             try {
-                return MessageType.fromRootElement(root, namespace);
+                if (namespace != null && !namespace.isBlank()) {
+                    return MessageType.fromRootElement(root, namespace);
+                }
+                return MessageType.fromRootElement(root);
             } catch (IllegalArgumentException ex) {
                 throw new SAXException(ex.getMessage(), ex);
             }
@@ -228,4 +231,3 @@ public class XSDValidator implements CIIValidator {
         }
     }
 }
-

--- a/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/validator/SchemaVersionTest.java
+++ b/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/validator/SchemaVersionTest.java
@@ -1,0 +1,38 @@
+package com.cii.messaging.validator;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SchemaVersionTest {
+
+    private String originalSystemProperty;
+
+    @BeforeEach
+    void captureProperty() {
+        originalSystemProperty = System.getProperty("unece.version");
+    }
+
+    @AfterEach
+    void restoreProperty() {
+        if (originalSystemProperty != null) {
+            System.setProperty("unece.version", originalSystemProperty);
+        } else {
+            System.clearProperty("unece.version");
+        }
+    }
+
+    @Test
+    void systemPropertyOverridesDefaultVersion() {
+        System.setProperty("unece.version", "D24A");
+        assertEquals(SchemaVersion.D24A, SchemaVersion.getDefault());
+    }
+
+    @Test
+    void fallsBackToBundledVersionWhenNoOverride() {
+        System.clearProperty("unece.version");
+        assertEquals(SchemaVersion.D23B, SchemaVersion.getDefault());
+}
+}

--- a/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/WriterConfig.java
+++ b/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/WriterConfig.java
@@ -8,13 +8,7 @@ import lombok.Data;
 public class WriterConfig {
     @Builder.Default
     private boolean formatOutput = true;
-    
+
     @Builder.Default
     private String encoding = "UTF-8";
-    
-    @Builder.Default
-    private boolean includeNamespaces = true;
-    
-    @Builder.Default
-    private String indentation = "  ";
 }

--- a/cii-messaging-parent/cii-writer/src/test/resources/order-sample.xml
+++ b/cii-messaging-parent/cii-writer/src/test/resources/order-sample.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rsm:CrossIndustryOrder xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryOrder:16"
-                        xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:16"
-                        xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:16">
+<rsm:CrossIndustryOrder xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryOrder:100"
+                        xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+                        xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
     <rsm:ExchangedDocument>
         <ram:ID>ORD-2024-001</ram:ID>
         <ram:TypeCode>220</ram:TypeCode>


### PR DESCRIPTION
## Summary
- align the order model and all order samples on the UN/CEFACT 100 namespace and add an explicit legacy sample for failure scenarios
- harden XML parsing by caching reader instances, using secure StAX unmarshalling, and enforcing namespace-aware message type detection
- tighten validator message type and schema version resolution, add secure schema factory options, and cover the default resolution path with tests

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68c8653f3dcc832e83712b658be4042a