### PR TITLE
Setup JUnit scaffolding for CII XML tests

### DIFF
--- a/cii-messaging-parent/cii-reader/pom.xml
+++ b/cii-messaging-parent/cii-reader/pom.xml
@@ -32,6 +32,12 @@
             <artifactId>jaxb-impl</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.cii.messaging</groupId>
+            <artifactId>cii-samples</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/cii-messaging-parent/cii-reader/src/test/java/com/cii/messaging/test/cii/reader/CiiReaderXmlSamplesTest.java
+++ b/cii-messaging-parent/cii-reader/src/test/java/com/cii/messaging/test/cii/reader/CiiReaderXmlSamplesTest.java
@@ -1,0 +1,47 @@
+package com.cii.messaging.test.cii.reader;
+
+import com.cii.messaging.test.cii.support.CiiSampleResource;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Skeleton test suite prepared for future reader-oriented unit tests.  The
+ * structure mirrors the main {@code cii-reader} responsibilities (parsing
+ * multiple Cross Industry message types and handling defensive XML parsing).
+ */
+@DisplayName("CII Reader – XML processing contract")
+class CiiReaderXmlSamplesTest {
+
+    @Nested
+    @DisplayName("Order samples")
+    class OrderSamples {
+
+        @Test
+        @Disabled("Reader implementation tests to be provided in a future iteration")
+        void shouldParseOrderSample() {
+            var samples = new CiiSampleResource();
+            // Placeholder for future parsing assertion using samples.open("order-sample.xml")
+        }
+    }
+
+    @Nested
+    @DisplayName("Invoice samples")
+    class InvoiceSamples {
+
+        @Test
+        @Disabled("Reader implementation tests to be provided in a future iteration")
+        void shouldParseInvoiceSample() {
+            var samples = new CiiSampleResource();
+            // Placeholder for future parsing assertion using samples.open("invoice-sample.xml")
+        }
+    }
+
+    @Test
+    @Disabled("Security hardening tests to be provided in a future iteration")
+    @DisplayName("Rejects XML entities and dangerous constructs")
+    void shouldProtectAgainstXxePayloads() {
+        // Placeholder for future XXE protection check leveraging secure parser configuration
+    }
+}

--- a/cii-messaging-parent/cii-reader/src/test/java/com/cii/messaging/test/cii/support/CiiSampleResource.java
+++ b/cii-messaging-parent/cii-reader/src/test/java/com/cii/messaging/test/cii/support/CiiSampleResource.java
@@ -1,0 +1,32 @@
+package com.cii.messaging.test.cii.support;
+
+import java.io.InputStream;
+import java.util.Objects;
+
+/**
+ * Lightweight helper exposing access to the XML fixtures published by the
+ * {@code cii-samples} module.  Tests can load resources by their simple file
+ * name without having to repeat classpath boilerplate.
+ */
+public final class CiiSampleResource {
+
+    /** Base folder inside {@code cii-samples} where XML examples are stored. */
+    public static final String SAMPLE_FOLDER = "samples/";
+
+    /**
+     * Opens a resource stream pointing to the requested sample XML file.
+     *
+     * @param sampleFileName the simple file name (e.g. {@code invoice-sample.xml})
+     * @return a non-null input stream ready to be consumed by the caller
+     * @throws IllegalArgumentException if the resource cannot be located on the classpath
+     */
+    public InputStream open(String sampleFileName) {
+        Objects.requireNonNull(sampleFileName, "sampleFileName must not be null");
+        var resource = SAMPLE_FOLDER + sampleFileName;
+        var stream = Thread.currentThread().getContextClassLoader().getResourceAsStream(resource);
+        if (stream == null) {
+            throw new IllegalArgumentException("Unable to locate sample resource: " + resource);
+        }
+        return stream;
+    }
+}

--- a/cii-messaging-parent/cii-reader/src/test/resources/README.md
+++ b/cii-messaging-parent/cii-reader/src/test/resources/README.md
@@ -1,0 +1,5 @@
+# Test resources for cii-reader
+
+This directory is reserved for reader-specific fixtures. Tests should
+prefer loading the canonical XML documents published by the `cii-samples`
+module via the `CiiSampleResource` helper.

--- a/cii-messaging-parent/cii-validator/pom.xml
+++ b/cii-messaging-parent/cii-validator/pom.xml
@@ -46,6 +46,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.cii.messaging</groupId>
+            <artifactId>cii-samples</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/test/cii/support/CiiSampleResource.java
+++ b/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/test/cii/support/CiiSampleResource.java
@@ -1,0 +1,22 @@
+package com.cii.messaging.test.cii.support;
+
+import java.io.InputStream;
+import java.util.Objects;
+
+/**
+ * Shared helper to retrieve XML examples packaged in {@code cii-samples}.
+ */
+public final class CiiSampleResource {
+
+    public static final String SAMPLE_FOLDER = "samples/";
+
+    public InputStream open(String sampleFileName) {
+        Objects.requireNonNull(sampleFileName, "sampleFileName must not be null");
+        var resource = SAMPLE_FOLDER + sampleFileName;
+        var stream = Thread.currentThread().getContextClassLoader().getResourceAsStream(resource);
+        if (stream == null) {
+            throw new IllegalArgumentException("Unable to locate sample resource: " + resource);
+        }
+        return stream;
+    }
+}

--- a/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/test/cii/validator/CiiValidatorComplianceTest.java
+++ b/cii-messaging-parent/cii-validator/src/test/java/com/cii/messaging/test/cii/validator/CiiValidatorComplianceTest.java
@@ -1,0 +1,47 @@
+package com.cii.messaging.test.cii.validator;
+
+import com.cii.messaging.test.cii.support.CiiSampleResource;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Blueprint for upcoming validation scenarios combining XSD and Schematron
+ * rules.  The structure highlights key validation angles (schema compliance,
+ * business rules, error reporting) without enforcing them yet.
+ */
+@DisplayName("CII Validator – compliance checks")
+class CiiValidatorComplianceTest {
+
+    @Nested
+    @DisplayName("Schema validation")
+    class SchemaValidation {
+
+        @Test
+        @Disabled("XSD validation tests to be added later")
+        void shouldValidateInvoiceSampleAgainstXsd() {
+            var samples = new CiiSampleResource();
+            // Placeholder for XSD validation logic using invoice-sample.xml
+        }
+    }
+
+    @Nested
+    @DisplayName("Schematron business rules")
+    class SchematronValidation {
+
+        @Test
+        @Disabled("Schematron validation tests to be added later")
+        void shouldValidateOrderSampleAgainstSchematron() {
+            var samples = new CiiSampleResource();
+            // Placeholder for Schematron validation logic using order-sample.xml
+        }
+    }
+
+    @Test
+    @Disabled("Error reporting tests to be added later")
+    @DisplayName("Collects validation failures with diagnostic details")
+    void shouldExposeReadableValidationErrors() {
+        // Placeholder for asserting structured error reporting from validator
+    }
+}

--- a/cii-messaging-parent/cii-validator/src/test/resources/README.md
+++ b/cii-messaging-parent/cii-validator/src/test/resources/README.md
@@ -1,0 +1,5 @@
+# Test resources for cii-validator
+
+Validator-focused fixtures (e.g. invalid payloads or Schematron stubs)
+can be staged here. Default XML examples should be accessed from the
+`cii-samples` module through the `CiiSampleResource` helper.

--- a/cii-messaging-parent/cii-writer/pom.xml
+++ b/cii-messaging-parent/cii-writer/pom.xml
@@ -45,6 +45,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.cii.messaging</groupId>
+            <artifactId>cii-samples</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/test/cii/support/CiiSampleResource.java
+++ b/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/test/cii/support/CiiSampleResource.java
@@ -1,0 +1,22 @@
+package com.cii.messaging.test.cii.support;
+
+import java.io.InputStream;
+import java.util.Objects;
+
+/**
+ * Utility to access XML samples supplied by the {@code cii-samples} module.
+ */
+public final class CiiSampleResource {
+
+    public static final String SAMPLE_FOLDER = "samples/";
+
+    public InputStream open(String sampleFileName) {
+        Objects.requireNonNull(sampleFileName, "sampleFileName must not be null");
+        var resource = SAMPLE_FOLDER + sampleFileName;
+        var stream = Thread.currentThread().getContextClassLoader().getResourceAsStream(resource);
+        if (stream == null) {
+            throw new IllegalArgumentException("Unable to locate sample resource: " + resource);
+        }
+        return stream;
+    }
+}

--- a/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/test/cii/writer/CiiWriterXmlGenerationTest.java
+++ b/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/test/cii/writer/CiiWriterXmlGenerationTest.java
@@ -1,0 +1,47 @@
+package com.cii.messaging.test.cii.writer;
+
+import com.cii.messaging.test.cii.support.CiiSampleResource;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Scaffold for future writer-based assertions.  Tests will ensure the XML
+ * marshalling layer recreates the canonical documents published in the
+ * {@code cii-samples} module and respects formatting/security rules.
+ */
+@DisplayName("CII Writer – XML generation contract")
+class CiiWriterXmlGenerationTest {
+
+    @Nested
+    @DisplayName("Order rendering")
+    class OrderRendering {
+
+        @Test
+        @Disabled("Writer generation tests to be implemented later")
+        void shouldGenerateOrderXmlMatchingSample() {
+            var samples = new CiiSampleResource();
+            // Placeholder for JAXB marshalling assertions against order-sample.xml
+        }
+    }
+
+    @Nested
+    @DisplayName("Invoice rendering")
+    class InvoiceRendering {
+
+        @Test
+        @Disabled("Writer generation tests to be implemented later")
+        void shouldGenerateInvoiceXmlMatchingSample() {
+            var samples = new CiiSampleResource();
+            // Placeholder for JAXB marshalling assertions against invoice-sample.xml
+        }
+    }
+
+    @Test
+    @Disabled("Writer configuration tests to be implemented later")
+    @DisplayName("Applies canonical namespaces and encoding")
+    void shouldRespectCanonicalConfiguration() {
+        // Placeholder for verifying namespace prefixes, encoding and formatting settings
+    }
+}

--- a/cii-messaging-parent/cii-writer/src/test/resources/README.md
+++ b/cii-messaging-parent/cii-writer/src/test/resources/README.md
@@ -1,0 +1,5 @@
+# Test resources for cii-writer
+
+Custom fixtures specific to writer behaviour can be placed here. The
+canonical XML documents remain provided by the `cii-samples` module and
+are available to tests through the `CiiSampleResource` helper.


### PR DESCRIPTION
## Summary
- add the cii-samples module as a test-scoped dependency for reader, writer and validator builds so fixtures are available on the classpath
- scaffold dedicated JUnit 5 packages for XML reading, writing and validation with disabled placeholder suites
- document the new test resource folders and provide a helper to load canonical sample XML files

## Testing
- mvn -pl cii-reader,cii-writer,cii-validator -am test

------
https://chatgpt.com/codex/tasks/task_e_68ca9dad86e4832eb6449c89bcdd64e5