### PR TITLE
feat(writer): ajouter generateurs DESADV et INVOICE

### DIFF
--- a/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/order/Order.java
+++ b/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/order/Order.java
@@ -7,7 +7,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 /**
  * Dedicated model for orders based on UNECE CrossIndustryOrderType.
  */
-@XmlRootElement(name = "CrossIndustryOrder", namespace = "urn:un:unece:uncefact:data:standard:CrossIndustryOrder:100")
+@XmlRootElement(name = "CrossIndustryOrder", namespace = "urn:un:unece:uncefact:data:standard:CrossIndustryOrder:16")
 public class Order extends CrossIndustryOrderType {
     // Additional domain-specific helpers or validations can be added here later.
 }

--- a/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/analysis/OrderAnalysisResult.java
+++ b/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/analysis/OrderAnalysisResult.java
@@ -1,0 +1,238 @@
+package com.cii.messaging.reader.analysis;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Représente une vue synthétique d'une commande CII et de ses lignes.
+ */
+public final class OrderAnalysisResult {
+
+    private final String orderId;
+    private final String issueDate;
+    private final String buyerName;
+    private final String buyerIdentifier;
+    private final String buyerReference;
+    private final String sellerName;
+    private final String currency;
+    private final int lineCount;
+    private final List<OrderLineSummary> lines;
+
+    public OrderAnalysisResult(
+            String orderId,
+            String issueDate,
+            String buyerName,
+            String buyerIdentifier,
+            String buyerReference,
+            String sellerName,
+            String currency,
+            int lineCount,
+            List<OrderLineSummary> lines) {
+        this.orderId = orderId;
+        this.issueDate = issueDate;
+        this.buyerName = buyerName;
+        this.buyerIdentifier = buyerIdentifier;
+        this.buyerReference = buyerReference;
+        this.sellerName = sellerName;
+        this.currency = currency;
+        this.lineCount = lineCount;
+        this.lines = Collections.unmodifiableList(Objects.requireNonNull(lines, "lines"));
+    }
+
+    public String getOrderId() {
+        return orderId;
+    }
+
+    public String getIssueDate() {
+        return issueDate;
+    }
+
+    public String getBuyerName() {
+        return buyerName;
+    }
+
+    public String getBuyerIdentifier() {
+        return buyerIdentifier;
+    }
+
+    public String getBuyerReference() {
+        return buyerReference;
+    }
+
+    public String getSellerName() {
+        return sellerName;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public int getLineCount() {
+        return lineCount;
+    }
+
+    public List<OrderLineSummary> getLines() {
+        return lines;
+    }
+
+    /**
+     * Retourne un message multi-lignes prêt à afficher décrivant la commande.
+     */
+    public String toPrettyString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Commande");
+        if (orderId != null && !orderId.isBlank()) {
+            sb.append(' ').append(orderId);
+        }
+        sb.append('\n');
+
+        if (issueDate != null && !issueDate.isBlank()) {
+            sb.append("  Date d'émission : ").append(issueDate).append('\n');
+        }
+        if ((buyerName != null && !buyerName.isBlank()) || (buyerIdentifier != null && !buyerIdentifier.isBlank())) {
+            sb.append("  Acheteur : ");
+            if (buyerName != null && !buyerName.isBlank()) {
+                sb.append(buyerName);
+            }
+            if (buyerIdentifier != null && !buyerIdentifier.isBlank()) {
+                if (buyerName != null && !buyerName.isBlank()) {
+                    sb.append(" (ID : ").append(buyerIdentifier).append(')');
+                } else {
+                    sb.append(buyerIdentifier);
+                }
+            }
+            sb.append('\n');
+        }
+        if (buyerReference != null && !buyerReference.isBlank()) {
+            sb.append("  Référence acheteur : ").append(buyerReference).append('\n');
+        }
+        if (sellerName != null && !sellerName.isBlank()) {
+            sb.append("  Vendeur : ").append(sellerName).append('\n');
+        }
+        if (currency != null && !currency.isBlank()) {
+            sb.append("  Devise : ").append(currency).append('\n');
+        }
+        sb.append("  Nombre de lignes : ").append(lineCount).append('\n');
+
+        for (OrderLineSummary line : lines) {
+            sb.append("    - Ligne ");
+            if (line.getLineId() != null && !line.getLineId().isBlank()) {
+                sb.append(line.getLineId());
+            } else {
+                sb.append('?');
+            }
+            sb.append(" : ");
+            if (line.getProductName() != null && !line.getProductName().isBlank()) {
+                sb.append(line.getProductName());
+            } else if (line.getProductIdentifier() != null && !line.getProductIdentifier().isBlank()) {
+                sb.append(line.getProductIdentifier());
+            } else {
+                sb.append("Article sans nom");
+            }
+            if (line.getQuantity() != null) {
+                sb.append(" — Quantité : ").append(line.getQuantity());
+                if (line.getQuantityUnit() != null && !line.getQuantityUnit().isBlank()) {
+                    sb.append(' ').append(line.getQuantityUnit());
+                }
+            }
+            if (line.getNetPrice() != null) {
+                sb.append(" — Prix unitaire : ")
+                        .append(line.getNetPrice());
+                if (line.getNetPriceCurrency() != null && !line.getNetPriceCurrency().isBlank()) {
+                    sb.append(' ').append(line.getNetPriceCurrency());
+                }
+            }
+            if (line.getLineTotal() != null) {
+                sb.append(" — Total ligne : ")
+                        .append(line.getLineTotal());
+                String currencyCode = line.getLineTotalCurrency() != null && !line.getLineTotalCurrency().isBlank()
+                        ? line.getLineTotalCurrency()
+                        : currency;
+                if (currencyCode != null && !currencyCode.isBlank()) {
+                    sb.append(' ').append(currencyCode);
+                }
+            }
+            sb.append('\n');
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public String toString() {
+        return toPrettyString();
+    }
+
+    /**
+     * Résumé d'une ligne de commande.
+     */
+    public static final class OrderLineSummary {
+        private final String lineId;
+        private final String productIdentifier;
+        private final String productName;
+        private final BigDecimal quantity;
+        private final String quantityUnit;
+        private final BigDecimal netPrice;
+        private final String netPriceCurrency;
+        private final BigDecimal lineTotal;
+        private final String lineTotalCurrency;
+
+        public OrderLineSummary(
+                String lineId,
+                String productIdentifier,
+                String productName,
+                BigDecimal quantity,
+                String quantityUnit,
+                BigDecimal netPrice,
+                String netPriceCurrency,
+                BigDecimal lineTotal,
+                String lineTotalCurrency) {
+            this.lineId = lineId;
+            this.productIdentifier = productIdentifier;
+            this.productName = productName;
+            this.quantity = quantity;
+            this.quantityUnit = quantityUnit;
+            this.netPrice = netPrice;
+            this.netPriceCurrency = netPriceCurrency;
+            this.lineTotal = lineTotal;
+            this.lineTotalCurrency = lineTotalCurrency;
+        }
+
+        public String getLineId() {
+            return lineId;
+        }
+
+        public String getProductIdentifier() {
+            return productIdentifier;
+        }
+
+        public String getProductName() {
+            return productName;
+        }
+
+        public BigDecimal getQuantity() {
+            return quantity;
+        }
+
+        public String getQuantityUnit() {
+            return quantityUnit;
+        }
+
+        public BigDecimal getNetPrice() {
+            return netPrice;
+        }
+
+        public String getNetPriceCurrency() {
+            return netPriceCurrency;
+        }
+
+        public BigDecimal getLineTotal() {
+            return lineTotal;
+        }
+
+        public String getLineTotalCurrency() {
+            return lineTotalCurrency;
+        }
+    }
+}

--- a/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/analysis/OrderAnalyzer.java
+++ b/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/analysis/OrderAnalyzer.java
@@ -1,0 +1,292 @@
+package com.cii.messaging.reader.analysis;
+
+import com.cii.messaging.model.order.Order;
+import com.cii.messaging.reader.CIIReaderException;
+import com.cii.messaging.reader.OrderReader;
+import com.cii.messaging.unece.order.AmountType;
+import com.cii.messaging.unece.order.CurrencyCodeType;
+import com.cii.messaging.unece.order.DateTimeType;
+import com.cii.messaging.unece.order.DocumentLineDocumentType;
+import com.cii.messaging.unece.order.HeaderTradeAgreementType;
+import com.cii.messaging.unece.order.HeaderTradeSettlementType;
+import com.cii.messaging.unece.order.IDType;
+import com.cii.messaging.unece.order.LineTradeAgreementType;
+import com.cii.messaging.unece.order.LineTradeDeliveryType;
+import com.cii.messaging.unece.order.LineTradeSettlementType;
+import com.cii.messaging.unece.order.QuantityType;
+import com.cii.messaging.unece.order.SupplyChainTradeLineItemType;
+import com.cii.messaging.unece.order.SupplyChainTradeTransactionType;
+import com.cii.messaging.unece.order.TextType;
+import com.cii.messaging.unece.order.TradePartyType;
+import com.cii.messaging.unece.order.TradePriceType;
+import com.cii.messaging.unece.order.TradeProductType;
+import com.cii.messaging.unece.order.TradeSettlementLineMonetarySummationType;
+
+import java.io.File;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Utilitaire qui lit un fichier CrossIndustryOrder et en propose un résumé exploitable.
+ */
+public final class OrderAnalyzer {
+
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ISO_LOCAL_DATE;
+    private static final DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+    private OrderAnalyzer() {
+        // utilitaire
+    }
+
+    /**
+     * Lit un fichier XML de commande et retourne un objet métier contenant les informations principales.
+     *
+     * @param cheminFichier chemin vers le fichier ORDER XML
+     * @return les informations extraites
+     * @throws IOException        si le fichier est introuvable ou inaccessible
+     * @throws CIIReaderException si la désérialisation échoue
+     */
+    public static OrderAnalysisResult analyserOrder(String cheminFichier) throws IOException, CIIReaderException {
+        Objects.requireNonNull(cheminFichier, "cheminFichier");
+        Path path = Path.of(cheminFichier);
+        if (!Files.exists(path) || !Files.isRegularFile(path)) {
+            throw new IOException("Fichier XML introuvable : " + cheminFichier);
+        }
+
+        OrderReader reader = new OrderReader();
+        Order order = reader.read(new File(cheminFichier));
+        return analyse(order);
+    }
+
+    private static OrderAnalysisResult analyse(Order order) {
+        String orderId = null;
+        String issueDate = null;
+        String currency = null;
+        String buyerName = null;
+        String buyerId = null;
+        String buyerReference = null;
+        String sellerName = null;
+        List<OrderAnalysisResult.OrderLineSummary> lines = new ArrayList<>();
+
+        if (order.getExchangedDocument() != null) {
+            if (order.getExchangedDocument().getID() != null) {
+                orderId = safeValue(order.getExchangedDocument().getID());
+            }
+            issueDate = formatIssueDate(order.getExchangedDocument().getIssueDateTime());
+        }
+
+        SupplyChainTradeTransactionType transaction = order.getSupplyChainTradeTransaction();
+        if (transaction != null) {
+            HeaderTradeAgreementType agreement = transaction.getApplicableHeaderTradeAgreement();
+            if (agreement != null) {
+                buyerReference = safeValue(agreement.getBuyerReference());
+                TradePartyType buyer = agreement.getBuyerTradeParty();
+                if (buyer != null) {
+                    buyerName = safeValue(buyer.getName());
+                    buyerId = firstIdValue(buyer.getID());
+                }
+                TradePartyType seller = agreement.getSellerTradeParty();
+                if (seller != null) {
+                    sellerName = safeValue(seller.getName());
+                }
+            }
+
+            HeaderTradeSettlementType settlement = transaction.getApplicableHeaderTradeSettlement();
+            if (settlement != null) {
+                currency = safeCurrency(settlement.getOrderCurrencyCode());
+            }
+
+            List<SupplyChainTradeLineItemType> lineItems = transaction.getIncludedSupplyChainTradeLineItem();
+            for (SupplyChainTradeLineItemType lineItem : lineItems) {
+                lines.add(mapLine(lineItem, currency));
+            }
+        }
+
+        int lineCount = lines.size();
+        return new OrderAnalysisResult(orderId, issueDate, buyerName, buyerId, buyerReference, sellerName, currency, lineCount, lines);
+    }
+
+    private static OrderAnalysisResult.OrderLineSummary mapLine(SupplyChainTradeLineItemType lineItem, String defaultCurrency) {
+        String lineId = null;
+        String productIdentifier = null;
+        String productName = null;
+        BigDecimal quantityValue = null;
+        String quantityUnit = null;
+        BigDecimal netPriceValue = null;
+        String netPriceCurrency = null;
+        BigDecimal lineTotalValue = null;
+        String lineCurrency = null;
+
+        if (lineItem.getAssociatedDocumentLineDocument() != null) {
+            DocumentLineDocumentType lineDocument = lineItem.getAssociatedDocumentLineDocument();
+            if (lineDocument.getLineID() != null) {
+                lineId = safeValue(lineDocument.getLineID());
+            }
+        }
+
+        TradeProductType product = lineItem.getSpecifiedTradeProduct();
+        if (product != null) {
+            productName = firstTextValue(product.getName());
+            if (productName == null) {
+                productName = safeValue(product.getTradeName());
+            }
+            if (product.getGlobalID() != null && !product.getGlobalID().isEmpty()) {
+                productIdentifier = safeValue(product.getGlobalID().get(0));
+            } else if (product.getID() != null) {
+                productIdentifier = safeValue(product.getID());
+            } else if (product.getSellerAssignedID() != null) {
+                productIdentifier = safeValue(product.getSellerAssignedID());
+            }
+        }
+
+        LineTradeDeliveryType delivery = lineItem.getSpecifiedLineTradeDelivery();
+        if (delivery != null && delivery.getRequestedQuantity() != null) {
+            QuantityType requestedQuantity = delivery.getRequestedQuantity();
+            quantityValue = requestedQuantity.getValue();
+            quantityUnit = requestedQuantity.getUnitCode();
+        }
+
+        LineTradeAgreementType lineAgreement = lineItem.getSpecifiedLineTradeAgreement();
+        if (lineAgreement != null && lineAgreement.getNetPriceProductTradePrice() != null) {
+            TradePriceType price = lineAgreement.getNetPriceProductTradePrice();
+            AmountType netAmount = firstAmount(price.getChargeAmount());
+            if (netAmount != null) {
+                netPriceValue = netAmount.getValue();
+                netPriceCurrency = netAmount.getCurrencyID();
+            }
+        }
+
+        LineTradeSettlementType lineSettlement = lineItem.getSpecifiedLineTradeSettlement();
+        if (lineSettlement != null) {
+            TradeSettlementLineMonetarySummationType summary = lineSettlement.getSpecifiedTradeSettlementLineMonetarySummation();
+            if (summary != null) {
+                AmountType totalAmount = firstAmount(summary.getLineTotalAmount());
+                if (totalAmount == null) {
+                    totalAmount = firstAmount(summary.getNetLineTotalAmount());
+                }
+                if (totalAmount != null) {
+                    lineTotalValue = totalAmount.getValue();
+                    lineCurrency = totalAmount.getCurrencyID();
+                }
+            }
+        }
+
+        if (lineCurrency == null) {
+            lineCurrency = defaultCurrency;
+        }
+
+        return new OrderAnalysisResult.OrderLineSummary(
+                lineId,
+                productIdentifier,
+                productName,
+                quantityValue,
+                quantityUnit,
+                netPriceValue,
+                netPriceCurrency,
+                lineTotalValue,
+                lineCurrency
+        );
+    }
+
+    private static AmountType firstAmount(List<AmountType> amounts) {
+        if (amounts == null || amounts.isEmpty()) {
+            return null;
+        }
+        return amounts.get(0);
+    }
+
+    private static String firstTextValue(List<TextType> texts) {
+        if (texts == null || texts.isEmpty()) {
+            return null;
+        }
+        return safeValue(texts.get(0));
+    }
+
+    private static String firstIdValue(List<IDType> ids) {
+        if (ids == null || ids.isEmpty()) {
+            return null;
+        }
+        return safeValue(ids.get(0));
+    }
+
+    private static String safeValue(TextType textType) {
+        return textType != null ? textType.getValue() : null;
+    }
+
+    private static String safeValue(IDType id) {
+        return id != null ? id.getValue() : null;
+    }
+
+    private static String safeCurrency(CurrencyCodeType currencyCode) {
+        if (currencyCode == null || currencyCode.getValue() == null) {
+            return null;
+        }
+        return currencyCode.getValue().value();
+    }
+
+    private static String formatIssueDate(DateTimeType dateTime) {
+        if (dateTime == null) {
+            return null;
+        }
+        if (dateTime.getDateTime() != null) {
+            return DATE_TIME_FORMAT.format(dateTime.getDateTime().toGregorianCalendar().toZonedDateTime().toLocalDateTime());
+        }
+        if (dateTime.getDateTimeString() != null) {
+            String rawValue = dateTime.getDateTimeString().getValue();
+            String format = dateTime.getDateTimeString().getFormat();
+            String formatted = parseDateTimeString(rawValue, format);
+            if (formatted != null) {
+                return formatted;
+            }
+            return rawValue;
+        }
+        return null;
+    }
+
+    private static String parseDateTimeString(String rawValue, String formatCode) {
+        if (rawValue == null || rawValue.isBlank()) {
+            return null;
+        }
+        List<DateTimeFormatter> candidates = new ArrayList<>();
+        if ("102".equals(formatCode)) {
+            candidates.add(DateTimeFormatter.ofPattern("yyyyMMdd"));
+            candidates.add(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
+        }
+        if (rawValue.length() == 8) {
+            candidates.add(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        }
+        if (rawValue.length() == 12) {
+            candidates.add(DateTimeFormatter.ofPattern("yyyyMMddHHmm"));
+        }
+        if (rawValue.length() == 14) {
+            candidates.add(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
+        }
+
+        for (DateTimeFormatter formatter : candidates) {
+            if (formatter == null) {
+                continue;
+            }
+            try {
+                LocalDateTime dateTime = LocalDateTime.parse(rawValue, formatter);
+                return DATE_TIME_FORMAT.format(dateTime);
+            } catch (DateTimeParseException ignored) {
+                try {
+                    LocalDate date = LocalDate.parse(rawValue, formatter);
+                    return DATE_FORMAT.format(date);
+                } catch (DateTimeParseException ignoredAgain) {
+                    // on tente le formateur suivant
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/DesadvGenerator.java
+++ b/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/DesadvGenerator.java
@@ -1,0 +1,57 @@
+package com.cii.messaging.writer.generation;
+
+import com.cii.messaging.model.despatchadvice.DespatchAdvice;
+import com.cii.messaging.writer.CIIWriterException;
+import com.cii.messaging.writer.DesadvWriter;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * Utilitaire dédié à la génération de messages DESADV au format XML.
+ */
+public final class DesadvGenerator {
+
+    private DesadvGenerator() {
+        // utilitaire
+    }
+
+    /**
+     * Génère un fichier DESADV XML depuis l'objet métier fourni et retourne un message de confirmation.
+     *
+     * @param desadv       représentation métier de l'avis d'expédition
+     * @param cheminSortie chemin du fichier à générer
+     * @return un message décrivant l'emplacement du fichier généré
+     * @throws IOException        si le chemin est invalide ou si l'écriture échoue au niveau du système de fichiers
+     * @throws CIIWriterException si la sérialisation JAXB échoue
+     */
+    public static String genererDesadv(ObjetDesadv desadv, String cheminSortie)
+            throws IOException, CIIWriterException {
+        Objects.requireNonNull(desadv, "desadv");
+        Objects.requireNonNull(cheminSortie, "cheminSortie");
+
+        if (cheminSortie.isBlank()) {
+            throw new IllegalArgumentException("Le chemin de sortie ne peut pas être vide");
+        }
+
+        DespatchAdvice despatchAdvice = Objects.requireNonNull(desadv.toDespatchAdvice(),
+                "L'objet desadv doit fournir une instance DespatchAdvice valide");
+
+        Path outputPath = Path.of(cheminSortie);
+        Path parent = outputPath.toAbsolutePath().getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+
+        if (Files.exists(outputPath) && Files.isDirectory(outputPath)) {
+            throw new IOException("Le chemin de sortie correspond à un répertoire : " + cheminSortie);
+        }
+
+        DesadvWriter writer = new DesadvWriter();
+        writer.write(despatchAdvice, outputPath.toFile());
+
+        return "Fichier DESADV généré avec succès : " + outputPath.toAbsolutePath();
+    }
+}

--- a/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/InvoiceGenerator.java
+++ b/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/InvoiceGenerator.java
@@ -1,0 +1,57 @@
+package com.cii.messaging.writer.generation;
+
+import com.cii.messaging.model.invoice.Invoice;
+import com.cii.messaging.writer.CIIWriterException;
+import com.cii.messaging.writer.InvoiceWriter;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * Utilitaire dédié à la génération de messages INVOICE au format XML.
+ */
+public final class InvoiceGenerator {
+
+    private InvoiceGenerator() {
+        // utilitaire
+    }
+
+    /**
+     * Génère un fichier INVOICE XML depuis l'objet métier fourni et retourne un message de confirmation.
+     *
+     * @param invoice      représentation métier de la facture
+     * @param cheminSortie chemin du fichier à générer
+     * @return un message décrivant l'emplacement du fichier généré
+     * @throws IOException        si le chemin est invalide ou si l'écriture échoue au niveau du système de fichiers
+     * @throws CIIWriterException si la sérialisation JAXB échoue
+     */
+    public static String genererInvoice(ObjetInvoice invoice, String cheminSortie)
+            throws IOException, CIIWriterException {
+        Objects.requireNonNull(invoice, "invoice");
+        Objects.requireNonNull(cheminSortie, "cheminSortie");
+
+        if (cheminSortie.isBlank()) {
+            throw new IllegalArgumentException("Le chemin de sortie ne peut pas être vide");
+        }
+
+        Invoice invoiceMessage = Objects.requireNonNull(invoice.toInvoice(),
+                "L'objet invoice doit fournir une instance Invoice valide");
+
+        Path outputPath = Path.of(cheminSortie);
+        Path parent = outputPath.toAbsolutePath().getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+
+        if (Files.exists(outputPath) && Files.isDirectory(outputPath)) {
+            throw new IOException("Le chemin de sortie correspond à un répertoire : " + cheminSortie);
+        }
+
+        InvoiceWriter writer = new InvoiceWriter();
+        writer.write(invoiceMessage, outputPath.toFile());
+
+        return "Fichier INVOICE généré avec succès : " + outputPath.toAbsolutePath();
+    }
+}

--- a/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/ObjetCommande.java
+++ b/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/ObjetCommande.java
@@ -1,0 +1,17 @@
+package com.cii.messaging.writer.generation;
+
+import com.cii.messaging.model.order.Order;
+
+/**
+ * Représente une commande métier capable de produire un message {@link Order} prêt à être sérialisé.
+ */
+@FunctionalInterface
+public interface ObjetCommande {
+
+    /**
+     * Construit l'instance {@link Order} correspondant à la commande.
+     *
+     * @return le message {@link Order} prêt à être marshalled
+     */
+    Order toOrder();
+}

--- a/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/ObjetDesadv.java
+++ b/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/ObjetDesadv.java
@@ -1,0 +1,17 @@
+package com.cii.messaging.writer.generation;
+
+import com.cii.messaging.model.despatchadvice.DespatchAdvice;
+
+/**
+ * Représente un avis d'expédition métier capable de produire un message {@link DespatchAdvice} prêt à être sérialisé.
+ */
+@FunctionalInterface
+public interface ObjetDesadv {
+
+    /**
+     * Construit l'instance {@link DespatchAdvice} correspondant à l'avis d'expédition.
+     *
+     * @return le message {@link DespatchAdvice} prêt à être marshalled
+     */
+    DespatchAdvice toDespatchAdvice();
+}

--- a/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/ObjetInvoice.java
+++ b/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/ObjetInvoice.java
@@ -1,0 +1,17 @@
+package com.cii.messaging.writer.generation;
+
+import com.cii.messaging.model.invoice.Invoice;
+
+/**
+ * Représente une facture métier capable de produire un message {@link Invoice} prêt à être sérialisé.
+ */
+@FunctionalInterface
+public interface ObjetInvoice {
+
+    /**
+     * Construit l'instance {@link Invoice} correspondant à la facture.
+     *
+     * @return le message {@link Invoice} prêt à être marshalled
+     */
+    Invoice toInvoice();
+}

--- a/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/OrderGenerator.java
+++ b/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/OrderGenerator.java
@@ -1,0 +1,57 @@
+package com.cii.messaging.writer.generation;
+
+import com.cii.messaging.model.order.Order;
+import com.cii.messaging.writer.CIIWriterException;
+import com.cii.messaging.writer.OrderWriter;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * Utilitaire dédié à la génération de messages ORDERS au format XML.
+ */
+public final class OrderGenerator {
+
+    private OrderGenerator() {
+        // utilitaire
+    }
+
+    /**
+     * Génère un fichier ORDERS XML depuis l'objet métier fourni et retourne un message de confirmation.
+     *
+     * @param commande     représentation métier de la commande
+     * @param cheminSortie chemin du fichier à générer
+     * @return un message décrivant l'emplacement du fichier généré
+     * @throws IOException        si le chemin est invalide ou si l'écriture échoue au niveau du système de fichiers
+     * @throws CIIWriterException si la sérialisation JAXB échoue
+     */
+    public static String genererOrders(ObjetCommande commande, String cheminSortie)
+            throws IOException, CIIWriterException {
+        Objects.requireNonNull(commande, "commande");
+        Objects.requireNonNull(cheminSortie, "cheminSortie");
+
+        if (cheminSortie.isBlank()) {
+            throw new IllegalArgumentException("Le chemin de sortie ne peut pas être vide");
+        }
+
+        Order order = Objects.requireNonNull(commande.toOrder(),
+                "L'objet commande doit fournir une instance Order valide");
+
+        Path outputPath = Path.of(cheminSortie);
+        Path parent = outputPath.toAbsolutePath().getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+
+        if (Files.exists(outputPath) && Files.isDirectory(outputPath)) {
+            throw new IOException("Le chemin de sortie correspond à un répertoire : " + cheminSortie);
+        }
+
+        OrderWriter writer = new OrderWriter();
+        writer.write(order, outputPath.toFile());
+
+        return "Fichier ORDERS généré avec succès : " + outputPath.toAbsolutePath();
+    }
+}

--- a/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/generation/DesadvGeneratorTest.java
+++ b/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/generation/DesadvGeneratorTest.java
@@ -1,0 +1,192 @@
+package com.cii.messaging.writer.generation;
+
+import com.cii.messaging.model.despatchadvice.DespatchAdvice;
+import com.cii.messaging.unece.despatchadvice.CodeType;
+import com.cii.messaging.unece.despatchadvice.DateTimeType;
+import com.cii.messaging.unece.despatchadvice.DocumentCodeType;
+import com.cii.messaging.unece.despatchadvice.DocumentLineDocumentType;
+import com.cii.messaging.unece.despatchadvice.ExchangedDocumentContextType;
+import com.cii.messaging.unece.despatchadvice.ExchangedDocumentType;
+import com.cii.messaging.unece.despatchadvice.HeaderTradeAgreementType;
+import com.cii.messaging.unece.despatchadvice.HeaderTradeDeliveryType;
+import com.cii.messaging.unece.despatchadvice.IDType;
+import com.cii.messaging.unece.despatchadvice.LineTradeDeliveryType;
+import com.cii.messaging.unece.despatchadvice.QuantityType;
+import com.cii.messaging.unece.despatchadvice.SupplyChainEventType;
+import com.cii.messaging.unece.despatchadvice.SupplyChainTradeLineItemType;
+import com.cii.messaging.unece.despatchadvice.SupplyChainTradeTransactionType;
+import com.cii.messaging.unece.despatchadvice.TextType;
+import com.cii.messaging.unece.despatchadvice.TradePartyType;
+import com.cii.messaging.unece.despatchadvice.TradeProductType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.w3c.dom.Document;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathFactory;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DesadvGeneratorTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void shouldGenerateDesadvXmlAndReturnConfirmationMessage() throws Exception {
+        DespatchAdvice despatchAdvice = buildDespatchAdvice();
+        Path outputFile = tempDir.resolve("desadv.xml");
+
+        String message = DesadvGenerator.genererDesadv(() -> despatchAdvice, outputFile.toString());
+
+        assertTrue(message.startsWith("Fichier DESADV généré avec succès : "));
+        assertTrue(message.contains(outputFile.toAbsolutePath().toString()));
+        assertTrue(Files.exists(outputFile), "Le fichier DESADV n'a pas été créé");
+
+        String content = Files.readString(outputFile, StandardCharsets.UTF_8);
+        assertTrue(content.contains("CrossIndustryDespatchAdvice"));
+
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        Document document;
+        try (InputStream is = Files.newInputStream(outputFile)) {
+            document = factory.newDocumentBuilder().parse(is);
+        }
+        XPath xpath = XPathFactory.newInstance().newXPath();
+
+        assertEquals("CrossIndustryDespatchAdvice", document.getDocumentElement().getLocalName());
+        assertEquals("DESADV-2025-001", evaluate(xpath, document,
+                "/*[local-name()='CrossIndustryDespatchAdvice']/*[local-name()='ExchangedDocument']/*[local-name()='ID']"));
+        assertEquals("Expéditeur Logistique", evaluate(xpath, document,
+                "/*[local-name()='CrossIndustryDespatchAdvice']/*[local-name()='SupplyChainTradeTransaction']/*[local-name()='Applic"
+                        + "ableHeaderTradeAgreement']/*[local-name()='SellerTradeParty']/*[local-name()='Name']"));
+        assertEquals("Pompe hydraulique", evaluate(xpath, document,
+                "/*[local-name()='CrossIndustryDespatchAdvice']/*[local-name()='SupplyChainTradeTransaction']/*[local-name()='Included"
+                        + "SupplyChainTradeLineItem']/*[local-name()='SpecifiedTradeProduct']/*[local-name()='Name']"));
+        assertEquals("10", evaluate(xpath, document,
+                "/*[local-name()='CrossIndustryDespatchAdvice']/*[local-name()='SupplyChainTradeTransaction']/*[local-name()='Included"
+                        + "SupplyChainTradeLineItem']/*[local-name()='SpecifiedLineTradeDelivery']/*[local-name()='DespatchedQuantity']"));
+    }
+
+    private static DespatchAdvice buildDespatchAdvice() {
+        DespatchAdvice despatchAdvice = new DespatchAdvice();
+
+        ExchangedDocumentContextType context = new ExchangedDocumentContextType();
+        context.setSpecifiedTransactionID(id("TRANS-DES-001"));
+        despatchAdvice.setExchangedDocumentContext(context);
+
+        ExchangedDocumentType exchangedDocument = new ExchangedDocumentType();
+        exchangedDocument.setID(id("DESADV-2025-001"));
+        exchangedDocument.getName().add(text("Avis d'expédition"));
+        exchangedDocument.setTypeCode(documentCode("351"));
+        exchangedDocument.setIssueDateTime(dateTime("102", "20250116083000"));
+        despatchAdvice.setExchangedDocument(exchangedDocument);
+
+        SupplyChainTradeTransactionType transaction = new SupplyChainTradeTransactionType();
+        transaction.getShipmentID().add(id("SHIP-2025-01"));
+        transaction.setApplicableHeaderTradeAgreement(buildHeaderAgreement());
+        transaction.setApplicableHeaderTradeDelivery(buildHeaderDelivery());
+        transaction.getIncludedSupplyChainTradeLineItem().add(buildLineItem());
+        despatchAdvice.setSupplyChainTradeTransaction(transaction);
+
+        return despatchAdvice;
+    }
+
+    private static HeaderTradeAgreementType buildHeaderAgreement() {
+        HeaderTradeAgreementType agreement = new HeaderTradeAgreementType();
+        agreement.setSellerTradeParty(tradeParty("SELLER-01", "Expéditeur Logistique"));
+        agreement.setBuyerTradeParty(tradeParty("BUYER-01", "Client Industriel"));
+        return agreement;
+    }
+
+    private static HeaderTradeDeliveryType buildHeaderDelivery() {
+        HeaderTradeDeliveryType delivery = new HeaderTradeDeliveryType();
+        delivery.setShipFromTradeParty(tradeParty("FROM-01", "Entrepôt Nord"));
+        delivery.setShipToTradeParty(tradeParty("TO-99", "Usine Client"));
+
+        SupplyChainEventType despatchEvent = new SupplyChainEventType();
+        despatchEvent.setID(id("EVENT-01"));
+        despatchEvent.setOccurrenceDateTime(dateTime("102", "20250116103000"));
+        despatchEvent.setTypeCode(code("85"));
+        delivery.setActualDespatchSupplyChainEvent(despatchEvent);
+
+        return delivery;
+    }
+
+    private static SupplyChainTradeLineItemType buildLineItem() {
+        SupplyChainTradeLineItemType lineItem = new SupplyChainTradeLineItemType();
+        lineItem.setID(id("LINE-100"));
+
+        DocumentLineDocumentType lineDocument = new DocumentLineDocumentType();
+        lineDocument.setLineID(id("LINE-100"));
+        lineItem.setAssociatedDocumentLineDocument(lineDocument);
+
+        TradeProductType product = new TradeProductType();
+        product.getName().add(text("Pompe hydraulique"));
+        lineItem.getSpecifiedTradeProduct().add(product);
+
+        LineTradeDeliveryType lineDelivery = new LineTradeDeliveryType();
+        lineDelivery.setDespatchedQuantity(quantity("10", "EA"));
+        lineItem.getSpecifiedLineTradeDelivery().add(lineDelivery);
+
+        return lineItem;
+    }
+
+    private static TradePartyType tradeParty(String idValue, String name) {
+        TradePartyType party = new TradePartyType();
+        party.getID().add(id(idValue));
+        party.setName(text(name));
+        return party;
+    }
+
+    private static DocumentCodeType documentCode(String value) {
+        DocumentCodeType type = new DocumentCodeType();
+        type.setValue(value);
+        return type;
+    }
+
+    private static CodeType code(String value) {
+        CodeType code = new CodeType();
+        code.setValue(value);
+        return code;
+    }
+
+    private static DateTimeType dateTime(String format, String value) {
+        DateTimeType dateTime = new DateTimeType();
+        DateTimeType.DateTimeString dateTimeString = new DateTimeType.DateTimeString();
+        dateTimeString.setFormat(format);
+        dateTimeString.setValue(value);
+        dateTime.setDateTimeString(dateTimeString);
+        return dateTime;
+    }
+
+    private static IDType id(String value) {
+        IDType id = new IDType();
+        id.setValue(value);
+        return id;
+    }
+
+    private static TextType text(String value) {
+        TextType text = new TextType();
+        text.setValue(value);
+        return text;
+    }
+
+    private static QuantityType quantity(String value, String unitCode) {
+        QuantityType quantity = new QuantityType();
+        quantity.setValue(new BigDecimal(value));
+        quantity.setUnitCode(unitCode);
+        return quantity;
+    }
+
+    private static String evaluate(XPath xpath, Document document, String expression) throws Exception {
+        return xpath.evaluate(expression, document).trim();
+    }
+}

--- a/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/generation/InvoiceGeneratorTest.java
+++ b/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/generation/InvoiceGeneratorTest.java
@@ -1,0 +1,336 @@
+package com.cii.messaging.writer.generation;
+
+import com.cii.messaging.model.invoice.Invoice;
+import com.cii.messaging.unece.invoice.AmountType;
+import com.cii.messaging.unece.invoice.CodeType;
+import com.cii.messaging.unece.invoice.CountryIDType;
+import com.cii.messaging.unece.invoice.CurrencyCodeType;
+import com.cii.messaging.unece.invoice.DateTimeType;
+import com.cii.messaging.unece.invoice.DocumentCodeType;
+import com.cii.messaging.unece.invoice.DocumentLineDocumentType;
+import com.cii.messaging.unece.invoice.DutyTaxFeeTypeCodeContentType;
+import com.cii.messaging.unece.invoice.DutyorTaxorFeeCategoryCodeContentType;
+import com.cii.messaging.unece.invoice.ExchangedDocumentContextType;
+import com.cii.messaging.unece.invoice.ExchangedDocumentType;
+import com.cii.messaging.unece.invoice.HeaderTradeAgreementType;
+import com.cii.messaging.unece.invoice.HeaderTradeDeliveryType;
+import com.cii.messaging.unece.invoice.HeaderTradeSettlementType;
+import com.cii.messaging.unece.invoice.IDType;
+import com.cii.messaging.unece.invoice.ISO3AlphaCurrencyCodeContentType;
+import com.cii.messaging.unece.invoice.ISOTwoletterCountryCodeContentType;
+import com.cii.messaging.unece.invoice.LineTradeAgreementType;
+import com.cii.messaging.unece.invoice.LineTradeDeliveryType;
+import com.cii.messaging.unece.invoice.LineTradeSettlementType;
+import com.cii.messaging.unece.invoice.PercentType;
+import com.cii.messaging.unece.invoice.QuantityType;
+import com.cii.messaging.unece.invoice.SupplyChainEventType;
+import com.cii.messaging.unece.invoice.SupplyChainTradeLineItemType;
+import com.cii.messaging.unece.invoice.SupplyChainTradeTransactionType;
+import com.cii.messaging.unece.invoice.TaxCategoryCodeType;
+import com.cii.messaging.unece.invoice.TaxRegistrationType;
+import com.cii.messaging.unece.invoice.TaxTypeCodeType;
+import com.cii.messaging.unece.invoice.TextType;
+import com.cii.messaging.unece.invoice.TradeAddressType;
+import com.cii.messaging.unece.invoice.TradeContactType;
+import com.cii.messaging.unece.invoice.TradePartyType;
+import com.cii.messaging.unece.invoice.TradePaymentTermsType;
+import com.cii.messaging.unece.invoice.TradePriceType;
+import com.cii.messaging.unece.invoice.TradeProductType;
+import com.cii.messaging.unece.invoice.TradeSettlementHeaderMonetarySummationType;
+import com.cii.messaging.unece.invoice.TradeSettlementLineMonetarySummationType;
+import com.cii.messaging.unece.invoice.TradeTaxType;
+import com.cii.messaging.unece.invoice.UniversalCommunicationType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.w3c.dom.Document;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathFactory;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class InvoiceGeneratorTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void shouldGenerateInvoiceXmlAndReturnConfirmationMessage() throws Exception {
+        Invoice invoice = buildInvoice();
+        Path outputFile = tempDir.resolve("invoice.xml");
+
+        String message = InvoiceGenerator.genererInvoice(() -> invoice, outputFile.toString());
+
+        assertTrue(message.startsWith("Fichier INVOICE généré avec succès : "));
+        assertTrue(message.contains(outputFile.toAbsolutePath().toString()));
+        assertTrue(Files.exists(outputFile), "Le fichier INVOICE n'a pas été créé");
+
+        String content = Files.readString(outputFile, StandardCharsets.UTF_8);
+        assertTrue(content.contains("CrossIndustryInvoice"));
+
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        Document document;
+        try (InputStream is = Files.newInputStream(outputFile)) {
+            document = factory.newDocumentBuilder().parse(is);
+        }
+        XPath xpath = XPathFactory.newInstance().newXPath();
+
+        assertEquals("CrossIndustryInvoice", document.getDocumentElement().getLocalName());
+        assertEquals("INV-2025-0001", evaluate(xpath, document,
+                "/*[local-name()='CrossIndustryInvoice']/*[local-name()='ExchangedDocument']/*[local-name()='ID']"));
+        assertEquals("Fournisseur Industriel", evaluate(xpath, document,
+                "/*[local-name()='CrossIndustryInvoice']/*[local-name()='SupplyChainTradeTransaction']/*[local-name()='ApplicableHead"
+                        + "erTradeAgreement']/*[local-name()='SellerTradeParty']/*[local-name()='Name']"));
+        assertEquals("GTIN", evaluate(xpath, document,
+                "/*[local-name()='CrossIndustryInvoice']/*[local-name()='SupplyChainTradeTransaction']/*[local-name()='IncludedSupply"
+                        + "ChainTradeLineItem']/*[local-name()='SpecifiedTradeProduct']/*[local-name()='GlobalID']/@schemeID"));
+        assertEquals("1200.00", evaluate(xpath, document,
+                "/*[local-name()='CrossIndustryInvoice']/*[local-name()='SupplyChainTradeTransaction']/*[local-name()='ApplicableHeade"
+                        + "rTradeSettlement']/*[local-name()='DuePayableAmount']"));
+    }
+
+    private static Invoice buildInvoice() {
+        Invoice invoice = new Invoice();
+
+        ExchangedDocumentContextType context = new ExchangedDocumentContextType();
+        context.setSpecifiedTransactionID(id("TRANS-INV-2025-01"));
+        invoice.setExchangedDocumentContext(context);
+
+        invoice.setExchangedDocument(buildExchangedDocument());
+        invoice.setSupplyChainTradeTransaction(buildTransaction());
+
+        return invoice;
+    }
+
+    private static ExchangedDocumentType buildExchangedDocument() {
+        ExchangedDocumentType document = new ExchangedDocumentType();
+        document.setID(id("INV-2025-0001"));
+        document.getName().add(text("Facture client"));
+        document.setTypeCode(documentCode("380"));
+        document.setIssueDateTime(dateTime("102", "20250301101500"));
+        return document;
+    }
+
+    private static SupplyChainTradeTransactionType buildTransaction() {
+        SupplyChainTradeTransactionType transaction = new SupplyChainTradeTransactionType();
+        transaction.setApplicableHeaderTradeAgreement(buildHeaderAgreement());
+        transaction.setApplicableHeaderTradeDelivery(buildHeaderDelivery());
+        transaction.setApplicableHeaderTradeSettlement(buildHeaderSettlement());
+        transaction.getIncludedSupplyChainTradeLineItem().add(buildLineItem());
+        return transaction;
+    }
+
+    private static HeaderTradeAgreementType buildHeaderAgreement() {
+        HeaderTradeAgreementType agreement = new HeaderTradeAgreementType();
+        agreement.setBuyerReference(text("PO-78945"));
+        agreement.setSellerTradeParty(buildSeller());
+        agreement.setBuyerTradeParty(buildBuyer());
+        return agreement;
+    }
+
+    private static TradePartyType buildSeller() {
+        TradePartyType seller = new TradePartyType();
+        seller.getID().add(id("SEL-001"));
+        seller.setName(text("Fournisseur Industriel"));
+        seller.setPostalTradeAddress(address("75008", "10 Rue des Forges", "Paris", "FR"));
+        seller.getSpecifiedTaxRegistration().add(taxRegistration("FR123456789", "VA"));
+
+        TradeContactType contact = new TradeContactType();
+        contact.setPersonName(text("Alice Fournisseur"));
+        contact.setTelephoneUniversalCommunication(communication(null, "+33 1 02 03 04 05"));
+        contact.setEmailURIUniversalCommunication(communication("alice.fournisseur@supplier.fr", null));
+        seller.getDefinedTradeContact().add(contact);
+
+        return seller;
+    }
+
+    private static TradePartyType buildBuyer() {
+        TradePartyType buyer = new TradePartyType();
+        buyer.getID().add(id("BUY-009"));
+        buyer.setName(text("Client Services"));
+        buyer.setPostalTradeAddress(address("69002", "25 Avenue Centrale", "Lyon", "FR"));
+        return buyer;
+    }
+
+    private static HeaderTradeDeliveryType buildHeaderDelivery() {
+        HeaderTradeDeliveryType delivery = new HeaderTradeDeliveryType();
+
+        SupplyChainEventType deliveryEvent = new SupplyChainEventType();
+        deliveryEvent.setID(id("EVT-DELIVERY-2025"));
+        deliveryEvent.setOccurrenceDateTime(dateTime("102", "20250227"));
+        delivery.setActualDeliverySupplyChainEvent(deliveryEvent);
+
+        return delivery;
+    }
+
+    private static HeaderTradeSettlementType buildHeaderSettlement() {
+        HeaderTradeSettlementType settlement = new HeaderTradeSettlementType();
+        settlement.setInvoiceCurrencyCode(currency("EUR"));
+        settlement.getDuePayableAmount().add(amount("1200.00", "EUR"));
+        settlement.getSpecifiedTradePaymentTerms().add(paymentTerms());
+
+        TradeSettlementHeaderMonetarySummationType summation = new TradeSettlementHeaderMonetarySummationType();
+        summation.getLineTotalAmount().add(amount("1000.00", "EUR"));
+        summation.getTaxBasisTotalAmount().add(amount("1000.00", "EUR"));
+        summation.getTaxTotalAmount().add(amount("200.00", "EUR"));
+        summation.getGrandTotalAmount().add(amount("1200.00", "EUR"));
+        summation.getDuePayableAmount().add(amount("1200.00", "EUR"));
+        settlement.setSpecifiedTradeSettlementHeaderMonetarySummation(summation);
+
+        return settlement;
+    }
+
+    private static TradePaymentTermsType paymentTerms() {
+        TradePaymentTermsType terms = new TradePaymentTermsType();
+        terms.getDescription().add(text("Paiement à 30 jours"));
+        terms.setDueDateDateTime(dateTime("102", "20250331"));
+        return terms;
+    }
+
+    private static SupplyChainTradeLineItemType buildLineItem() {
+        SupplyChainTradeLineItemType lineItem = new SupplyChainTradeLineItemType();
+
+        DocumentLineDocumentType lineDocument = new DocumentLineDocumentType();
+        lineDocument.setLineID(id("LINE-01"));
+        lineItem.setAssociatedDocumentLineDocument(lineDocument);
+
+        TradeProductType product = new TradeProductType();
+        product.setGlobalID(id("4012345000001", "GTIN"));
+        product.getName().add(text("Pompe haute pression"));
+        lineItem.setSpecifiedTradeProduct(product);
+
+        LineTradeAgreementType lineAgreement = new LineTradeAgreementType();
+        TradePriceType price = new TradePriceType();
+        price.getChargeAmount().add(amount("250.00", "EUR"));
+        lineAgreement.setNetPriceProductTradePrice(price);
+        lineItem.setSpecifiedLineTradeAgreement(lineAgreement);
+
+        LineTradeDeliveryType lineDelivery = new LineTradeDeliveryType();
+        lineDelivery.setBilledQuantity(quantity("4", "EA"));
+        lineItem.setSpecifiedLineTradeDelivery(lineDelivery);
+
+        LineTradeSettlementType lineSettlement = new LineTradeSettlementType();
+        TradeTaxType tax = new TradeTaxType();
+        tax.getCalculatedAmount().add(amount("200.00", "EUR"));
+        tax.getBasisAmount().add(amount("1000.00", "EUR"));
+        TaxTypeCodeType taxTypeCode = new TaxTypeCodeType();
+        taxTypeCode.setValue(DutyTaxFeeTypeCodeContentType.VAT);
+        tax.setTypeCode(taxTypeCode);
+        TaxCategoryCodeType taxCategory = new TaxCategoryCodeType();
+        taxCategory.setValue(DutyorTaxorFeeCategoryCodeContentType.S);
+        tax.setCategoryCode(taxCategory);
+        PercentType rate = new PercentType();
+        rate.setValue(new BigDecimal("20"));
+        tax.setRateApplicablePercent(rate);
+        lineSettlement.getApplicableTradeTax().add(tax);
+
+        TradeSettlementLineMonetarySummationType lineSummation = new TradeSettlementLineMonetarySummationType();
+        lineSummation.getLineTotalAmount().add(amount("1000.00", "EUR"));
+        lineSummation.getTaxTotalAmount().add(amount("200.00", "EUR"));
+        lineSummation.getGrandTotalAmount().add(amount("1200.00", "EUR"));
+        lineSettlement.setSpecifiedTradeSettlementLineMonetarySummation(lineSummation);
+
+        lineItem.setSpecifiedLineTradeSettlement(lineSettlement);
+
+        return lineItem;
+    }
+
+    private static TradeAddressType address(String postcode, String lineOne, String city, String countryCode) {
+        TradeAddressType address = new TradeAddressType();
+        address.setPostcodeCode(code(postcode));
+        address.setLineOne(text(lineOne));
+        address.setCityName(text(city));
+        CountryIDType country = new CountryIDType();
+        country.setValue(ISOTwoletterCountryCodeContentType.valueOf(countryCode));
+        address.setCountryID(country);
+        return address;
+    }
+
+    private static TaxRegistrationType taxRegistration(String idValue, String schemeId) {
+        TaxRegistrationType registration = new TaxRegistrationType();
+        registration.setID(id(idValue, schemeId));
+        return registration;
+    }
+
+    private static UniversalCommunicationType communication(String uri, String number) {
+        UniversalCommunicationType communication = new UniversalCommunicationType();
+        if (uri != null) {
+            communication.setURIID(id(uri));
+        }
+        if (number != null) {
+            communication.setCompleteNumber(text(number));
+        }
+        return communication;
+    }
+
+    private static DocumentCodeType documentCode(String value) {
+        DocumentCodeType type = new DocumentCodeType();
+        type.setValue(value);
+        return type;
+    }
+
+    private static CurrencyCodeType currency(String currency) {
+        CurrencyCodeType currencyCode = new CurrencyCodeType();
+        currencyCode.setValue(ISO3AlphaCurrencyCodeContentType.valueOf(currency));
+        return currencyCode;
+    }
+
+    private static AmountType amount(String value, String currency) {
+        AmountType amount = new AmountType();
+        amount.setValue(new BigDecimal(value));
+        amount.setCurrencyID(currency);
+        return amount;
+    }
+
+    private static QuantityType quantity(String value, String unitCode) {
+        QuantityType quantity = new QuantityType();
+        quantity.setValue(new BigDecimal(value));
+        quantity.setUnitCode(unitCode);
+        return quantity;
+    }
+
+    private static DateTimeType dateTime(String format, String value) {
+        DateTimeType dateTime = new DateTimeType();
+        DateTimeType.DateTimeString dateTimeString = new DateTimeType.DateTimeString();
+        dateTimeString.setFormat(format);
+        dateTimeString.setValue(value);
+        dateTime.setDateTimeString(dateTimeString);
+        return dateTime;
+    }
+
+    private static IDType id(String value) {
+        IDType id = new IDType();
+        id.setValue(value);
+        return id;
+    }
+
+    private static IDType id(String value, String schemeId) {
+        IDType id = id(value);
+        id.setSchemeID(schemeId);
+        return id;
+    }
+
+    private static TextType text(String value) {
+        TextType text = new TextType();
+        text.setValue(value);
+        return text;
+    }
+
+    private static CodeType code(String value) {
+        CodeType code = new CodeType();
+        code.setValue(value);
+        return code;
+    }
+
+    private static String evaluate(XPath xpath, Document document, String expression) throws Exception {
+        return xpath.evaluate(expression, document).trim();
+    }
+}

--- a/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/generation/OrderGeneratorTest.java
+++ b/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/generation/OrderGeneratorTest.java
@@ -1,0 +1,202 @@
+package com.cii.messaging.writer.generation;
+
+import com.cii.messaging.model.order.Order;
+import com.cii.messaging.unece.order.AmountType;
+import com.cii.messaging.unece.order.CurrencyCodeType;
+import com.cii.messaging.unece.order.DateTimeType;
+import com.cii.messaging.unece.order.DocumentLineDocumentType;
+import com.cii.messaging.unece.order.ExchangedDocumentContextType;
+import com.cii.messaging.unece.order.ExchangedDocumentType;
+import com.cii.messaging.unece.order.HeaderTradeAgreementType;
+import com.cii.messaging.unece.order.HeaderTradeDeliveryType;
+import com.cii.messaging.unece.order.HeaderTradeSettlementType;
+import com.cii.messaging.unece.order.IDType;
+import com.cii.messaging.unece.order.ISO3AlphaCurrencyCodeContentType;
+import com.cii.messaging.unece.order.LineTradeAgreementType;
+import com.cii.messaging.unece.order.LineTradeDeliveryType;
+import com.cii.messaging.unece.order.LineTradeSettlementType;
+import com.cii.messaging.unece.order.QuantityType;
+import com.cii.messaging.unece.order.SupplyChainTradeLineItemType;
+import com.cii.messaging.unece.order.SupplyChainTradeTransactionType;
+import com.cii.messaging.unece.order.TextType;
+import com.cii.messaging.unece.order.TradePartyType;
+import com.cii.messaging.unece.order.TradePriceType;
+import com.cii.messaging.unece.order.TradeProductType;
+import com.cii.messaging.unece.order.TradeSettlementLineMonetarySummationType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.w3c.dom.Document;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathFactory;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OrderGeneratorTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void shouldGenerateOrdersXmlAndReturnConfirmationMessage() throws Exception {
+        Order order = buildOrder();
+        Path outputFile = tempDir.resolve("orders.xml");
+
+        String message = OrderGenerator.genererOrders(() -> order, outputFile.toString());
+
+        assertTrue(message.startsWith("Fichier ORDERS généré avec succès : "));
+        assertTrue(message.contains(outputFile.toAbsolutePath().toString()));
+        assertTrue(Files.exists(outputFile), "Le fichier ORDERS n'a pas été créé");
+
+        String content = Files.readString(outputFile, StandardCharsets.UTF_8);
+        assertTrue(content.contains("CrossIndustryOrder"));
+
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        Document document;
+        try (InputStream is = Files.newInputStream(outputFile)) {
+            document = factory.newDocumentBuilder().parse(is);
+        }
+        XPath xpath = XPathFactory.newInstance().newXPath();
+
+        assertEquals("CrossIndustryOrder", document.getDocumentElement().getLocalName());
+        assertEquals("DOC-123", evaluate(xpath, document,
+                "/*[local-name()='CrossIndustryOrder']/*[local-name()='ExchangedDocument']/*[local-name()='ID']"));
+        assertEquals("REF-001", evaluate(xpath, document,
+                "/*[local-name()='CrossIndustryOrder']/*[local-name()='SupplyChainTradeTransaction']/*[local-name()='ApplicableHeaderTradeAgreement']/*[local-name()='BuyerReference']"));
+        assertEquals("EUR", evaluate(xpath, document,
+                "/*[local-name()='CrossIndustryOrder']/*[local-name()='SupplyChainTradeTransaction']/*[local-name()='ApplicableHeaderTradeSettlement']/*[local-name()='OrderCurrencyCode']"));
+    }
+
+    private static Order buildOrder() {
+        Order order = new Order();
+
+        ExchangedDocumentContextType context = new ExchangedDocumentContextType();
+        context.setSpecifiedTransactionID(id("TRANS-123"));
+        order.setExchangedDocumentContext(context);
+
+        ExchangedDocumentType document = new ExchangedDocumentType();
+        document.setID(id("DOC-123"));
+        document.getName().add(text("Commande Test"));
+        DateTimeType issueDate = new DateTimeType();
+        DateTimeType.DateTimeString dateTimeString = new DateTimeType.DateTimeString();
+        dateTimeString.setFormat("102");
+        dateTimeString.setValue("20240210103000");
+        issueDate.setDateTimeString(dateTimeString);
+        document.setIssueDateTime(issueDate);
+        order.setExchangedDocument(document);
+
+        SupplyChainTradeTransactionType transaction = new SupplyChainTradeTransactionType();
+        transaction.setApplicableHeaderTradeAgreement(buildHeaderAgreement());
+        transaction.setApplicableHeaderTradeDelivery(buildHeaderDelivery());
+        transaction.setApplicableHeaderTradeSettlement(buildHeaderSettlement());
+        transaction.getIncludedSupplyChainTradeLineItem().add(buildLineItem());
+        order.setSupplyChainTradeTransaction(transaction);
+
+        return order;
+    }
+
+    private static HeaderTradeAgreementType buildHeaderAgreement() {
+        HeaderTradeAgreementType agreement = new HeaderTradeAgreementType();
+        agreement.setBuyerReference(text("REF-001"));
+
+        TradePartyType seller = new TradePartyType();
+        seller.getID().add(id("SELLER-123"));
+        seller.setName(text("Vendeur Exemple"));
+        agreement.setSellerTradeParty(seller);
+
+        TradePartyType buyer = new TradePartyType();
+        buyer.getID().add(id("BUYER-456"));
+        buyer.setName(text("Acheteur Exemple"));
+        agreement.setBuyerTradeParty(buyer);
+
+        return agreement;
+    }
+
+    private static HeaderTradeDeliveryType buildHeaderDelivery() {
+        HeaderTradeDeliveryType delivery = new HeaderTradeDeliveryType();
+        TradePartyType shipTo = new TradePartyType();
+        shipTo.setName(text("Entrepôt Acheteur"));
+        delivery.setShipToTradeParty(shipTo);
+        return delivery;
+    }
+
+    private static HeaderTradeSettlementType buildHeaderSettlement() {
+        HeaderTradeSettlementType settlement = new HeaderTradeSettlementType();
+        settlement.setOrderCurrencyCode(currency("EUR"));
+        settlement.getDuePayableAmount().add(amount("100.00", "EUR"));
+        return settlement;
+    }
+
+    private static SupplyChainTradeLineItemType buildLineItem() {
+        SupplyChainTradeLineItemType lineItem = new SupplyChainTradeLineItemType();
+
+        DocumentLineDocumentType lineDocument = new DocumentLineDocumentType();
+        lineDocument.setLineID(id("LINE-1"));
+        lineItem.setAssociatedDocumentLineDocument(lineDocument);
+
+        TradeProductType product = new TradeProductType();
+        product.getName().add(text("Produit Exemple"));
+        lineItem.setSpecifiedTradeProduct(product);
+
+        LineTradeAgreementType lineAgreement = new LineTradeAgreementType();
+        TradePriceType price = new TradePriceType();
+        price.getChargeAmount().add(amount("100.00", "EUR"));
+        lineAgreement.setNetPriceProductTradePrice(price);
+        lineItem.setSpecifiedLineTradeAgreement(lineAgreement);
+
+        LineTradeDeliveryType lineDelivery = new LineTradeDeliveryType();
+        lineDelivery.setRequestedQuantity(quantity("1", "EA"));
+        lineItem.setSpecifiedLineTradeDelivery(lineDelivery);
+
+        LineTradeSettlementType lineSettlement = new LineTradeSettlementType();
+        TradeSettlementLineMonetarySummationType summation = new TradeSettlementLineMonetarySummationType();
+        summation.getLineTotalAmount().add(amount("100.00", "EUR"));
+        lineSettlement.setSpecifiedTradeSettlementLineMonetarySummation(summation);
+        lineItem.setSpecifiedLineTradeSettlement(lineSettlement);
+
+        return lineItem;
+    }
+
+    private static IDType id(String value) {
+        IDType id = new IDType();
+        id.setValue(value);
+        return id;
+    }
+
+    private static TextType text(String value) {
+        TextType text = new TextType();
+        text.setValue(value);
+        return text;
+    }
+
+    private static AmountType amount(String value, String currency) {
+        AmountType amount = new AmountType();
+        amount.setValue(new BigDecimal(value));
+        amount.setCurrencyID(currency);
+        return amount;
+    }
+
+    private static QuantityType quantity(String value, String unitCode) {
+        QuantityType quantity = new QuantityType();
+        quantity.setValue(new BigDecimal(value));
+        quantity.setUnitCode(unitCode);
+        return quantity;
+    }
+
+    private static CurrencyCodeType currency(String value) {
+        CurrencyCodeType currency = new CurrencyCodeType();
+        currency.setValue(ISO3AlphaCurrencyCodeContentType.valueOf(value));
+        return currency;
+    }
+
+    private static String evaluate(XPath xpath, Document document, String expression) throws Exception {
+        return xpath.evaluate(expression, document).trim();
+    }
+}


### PR DESCRIPTION
## Summary
- introduit les interfaces fonctionnelles `ObjetDesadv` et `ObjetInvoice` pour exposer les charges utiles prêtes à sérialiser
- ajoute `DesadvGenerator.genererDesadv` et `InvoiceGenerator.genererInvoice` avec validations de chemin et message de confirmation
- couvre la génération DESADV et INVOICE par des tests d’intégration vérifiant la structure XML produite

## Testing
- mvn -f cii-messaging-parent/pom.xml -pl cii-writer -am test

------
https://chatgpt.com/codex/tasks/task_e_68cabd05cd98832e8c009c81eaaeea97