### PR TITLE
Align order namespace with D23B samples

### DIFF
--- a/cii-messaging-parent/cii-cli/src/test/resources/order-sample.xml
+++ b/cii-messaging-parent/cii-cli/src/test/resources/order-sample.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rsm:CrossIndustryOrder xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryOrder:16"
-                        xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:16"
-                        xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:16">
+<rsm:CrossIndustryOrder xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryOrder:100"
+                        xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+                        xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+    <rsm:ExchangedDocumentContext>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+            <ram:ID>urn:cii:order:sample:guideline</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+    </rsm:ExchangedDocumentContext>
     <rsm:ExchangedDocument>
         <ram:ID>ORD-2024-001</ram:ID>
         <ram:TypeCode>220</ram:TypeCode>

--- a/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/order/Order.java
+++ b/cii-messaging-parent/cii-model/src/main/java/com/cii/messaging/model/order/Order.java
@@ -7,7 +7,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 /**
  * Dedicated model for orders based on UNECE CrossIndustryOrderType.
  */
-@XmlRootElement(name = "CrossIndustryOrder", namespace = "urn:un:unece:uncefact:data:standard:CrossIndustryOrder:16")
+@XmlRootElement(name = "CrossIndustryOrder", namespace = "urn:un:unece:uncefact:data:standard:CrossIndustryOrder:100")
 public class Order extends CrossIndustryOrderType {
     // Additional domain-specific helpers or validations can be added here later.
 }

--- a/cii-messaging-parent/cii-reader/src/test/resources/order-sample.xml
+++ b/cii-messaging-parent/cii-reader/src/test/resources/order-sample.xml
@@ -2,6 +2,11 @@
 <rsm:CrossIndustryOrder xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryOrder:100"
                         xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
                         xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+    <rsm:ExchangedDocumentContext>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+            <ram:ID>urn:cii:order:sample:guideline</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+    </rsm:ExchangedDocumentContext>
     <rsm:ExchangedDocument>
         <ram:ID>ORD-2024-001</ram:ID>
         <ram:TypeCode>220</ram:TypeCode>

--- a/cii-messaging-parent/cii-reader/src/test/resources/order-with-header.xml
+++ b/cii-messaging-parent/cii-reader/src/test/resources/order-with-header.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rsm:CrossIndustryOrder xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryOrder:16"
-                        xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:16"
-                        xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:16">
+<rsm:CrossIndustryOrder xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryOrder:100"
+                        xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+                        xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+    <rsm:ExchangedDocumentContext>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+            <ram:ID>urn:cii:order:sample:guideline</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+    </rsm:ExchangedDocumentContext>
     <rsm:ExchangedDocument>
         <ram:ID>ORD-2024-001</ram:ID>
         <ram:TypeCode>220</ram:TypeCode>

--- a/cii-messaging-parent/cii-samples/src/main/resources/samples/order-sample.xml
+++ b/cii-messaging-parent/cii-samples/src/main/resources/samples/order-sample.xml
@@ -2,6 +2,11 @@
 <rsm:CrossIndustryOrder xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryOrder:100"
                         xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
                         xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+    <rsm:ExchangedDocumentContext>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+            <ram:ID>urn:cii:order:sample:guideline</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+    </rsm:ExchangedDocumentContext>
     <rsm:ExchangedDocument>
         <ram:ID>ORD-2024-001</ram:ID>
         <ram:TypeCode>220</ram:TypeCode>

--- a/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/OrderWriterTest.java
+++ b/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/OrderWriterTest.java
@@ -63,7 +63,7 @@ class OrderWriterTest {
         Document document = factory.newDocumentBuilder().parse(new InputSource(new StringReader(xml)));
 
         assertEquals("CrossIndustryOrder", document.getDocumentElement().getLocalName());
-        assertEquals("urn:un:unece:uncefact:data:standard:CrossIndustryOrder:16",
+        assertEquals("urn:un:unece:uncefact:data:standard:CrossIndustryOrder:100",
                 document.getDocumentElement().getNamespaceURI());
 
         XPath xpath = XPathFactory.newInstance().newXPath();

--- a/cii-messaging-parent/cii-writer/src/test/resources/order-sample.xml
+++ b/cii-messaging-parent/cii-writer/src/test/resources/order-sample.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<rsm:CrossIndustryOrder xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryOrder:16"
-                        xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:16"
-                        xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:16">
+<rsm:CrossIndustryOrder xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryOrder:100"
+                        xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+                        xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+    <rsm:ExchangedDocumentContext>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+            <ram:ID>urn:cii:order:sample:guideline</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+    </rsm:ExchangedDocumentContext>
     <rsm:ExchangedDocument>
         <ram:ID>ORD-2024-001</ram:ID>
         <ram:TypeCode>220</ram:TypeCode>


### PR DESCRIPTION
## Summary
- update the Order JAXB root namespace to the D23B CrossIndustryOrder:100 value so reader/writer use the same schema version
- refresh order XML fixtures across modules to add a minimal ExchangedDocumentContext and the 100 namespaces expected by the schema
- adjust the writer namespace assertion to reflect the updated order namespace

## Testing
- mvn install

------
https://chatgpt.com/codex/tasks/task_e_68cba649b378832eae8aec97fcf4b4ee