### PR TITLE
Ensure build script runs from project root

### DIFF
--- a/cii-messaging-parent/scripts/build.sh
+++ b/cii-messaging-parent/scripts/build.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Script de build complet
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+cd "$SCRIPT_DIR/.." || exit 1
+
 echo "🏗️ Building CII Messaging System..."
 
 # Vérifier Java 21


### PR DESCRIPTION
## Summary
- ensure the build script determines its own location and switches to the project root so Maven and file copy steps run from the correct directory

## Testing
- bash cii-messaging-parent/scripts/build.sh
- ./build.sh

------
https://chatgpt.com/codex/tasks/task_e_68cbb850f478832ea8f53363871f4da2