### PR TITLE
Add strict error handling to build script

### DIFF
--- a/cii-messaging-parent/scripts/build.sh
+++ b/cii-messaging-parent/scripts/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 # Script de build complet
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
@@ -14,7 +15,10 @@ if [ "$java_version" -lt "21" ]; then
 fi
 
 # Clean et build
-mvn clean install -DskipTests
+if ! mvn clean install -DskipTests; then
+    echo "❌ Maven build failed. Aborting."
+    exit 1
+fi
 
 # Créer le répertoire de distribution
 mkdir -p dist


### PR DESCRIPTION
## Summary
- ensure the build script fails fast by enabling `set -euo pipefail`
- add a custom error message when the Maven build step fails

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cbba8dd2c8832e964ca24b9ea711f9