### PR TITLE
Improve build script robustness

### DIFF
--- a/cii-messaging-parent/scripts/build.sh
+++ b/cii-messaging-parent/scripts/build.sh
@@ -1,27 +1,41 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 # Script de build complet
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-cd "$SCRIPT_DIR/.." || exit 1
+PROJECT_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+
+if [ ! -f "${PROJECT_ROOT}/pom.xml" ]; then
+    echo "❌ Unable to locate pom.xml in ${PROJECT_ROOT}. Please run the script from the project repository."
+    exit 1
+fi
+
+cd "${PROJECT_ROOT}"
 
 echo "🏗️ Building CII Messaging System..."
 
 # Vérifier Java 21
 java_version=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}' | cut -d. -f1)
-if [ "$java_version" -lt "21" ]; then
+if [ "${java_version}" -lt "21" ]; then
     echo "❌ Java 21 or higher is required"
     exit 1
 fi
 
 # Clean et build
-if ! mvn clean install -DskipTests; then
+if ! mvn -f "${PROJECT_ROOT}/pom.xml" clean install -DskipTests; then
     echo "❌ Maven build failed. Aborting."
     exit 1
 fi
 
 # Créer le répertoire de distribution
 mkdir -p dist
-cp cii-cli/target/cii-cli-*-jar-with-dependencies.jar dist/cii-cli.jar
+CLI_JAR=$(find cii-cli/target -maxdepth 1 -name 'cii-cli-*-jar-with-dependencies.jar' -print -quit || true)
+
+if [ -z "${CLI_JAR}" ] || [ ! -f "${CLI_JAR}" ]; then
+    echo "❌ CLI jar introuvable dans cii-cli/target. Le build Maven est-il complet ?"
+    exit 1
+fi
+
+cp "${CLI_JAR}" dist/cii-cli.jar
 
 echo "✅ Build complete! CLI available at dist/cii-cli.jar"


### PR DESCRIPTION
## Summary
- ensure the build script resolves the project root before invoking Maven and verify the pom.xml exists
- call Maven with an explicit pom path and capture the CLI jar from the build output directory
- abort the build when the CLI jar cannot be found to avoid misleading success messages

## Testing
- ./scripts/build.sh

------
https://chatgpt.com/codex/tasks/task_e_68cbc1ce8a90832e9d4b002a5847b1da