### PR TITLE
Improve order summary parties and totals

### DIFF
--- a/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/analysis/OrderAnalysisResult.java
+++ b/cii-messaging-parent/cii-reader/src/main/java/com/cii/messaging/reader/analysis/OrderAnalysisResult.java
@@ -1,9 +1,11 @@
 package com.cii.messaging.reader.analysis;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.StringJoiner;
 
 /**
  * Représente une vue synthétique d'une commande CII et de ses lignes.
@@ -12,33 +14,55 @@ public final class OrderAnalysisResult {
 
     private final String orderId;
     private final String issueDate;
-    private final String buyerName;
-    private final String buyerIdentifier;
     private final String buyerReference;
-    private final String sellerName;
+    private final PartySummary orderingCustomer;
+    private final PartySummary buyer;
+    private final PartySummary invoicee;
+    private final PartySummary payer;
+    private final PartySummary seller;
+    private final PartySummary shipTo;
     private final String currency;
     private final int lineCount;
+    private final MonetaryAmount orderNetTotal;
+    private final MonetaryAmount orderTaxTotal;
+    private final MonetaryAmount orderGrossTotal;
+    private final List<TaxSummary> orderTaxes;
     private final List<OrderLineSummary> lines;
 
     public OrderAnalysisResult(
             String orderId,
             String issueDate,
-            String buyerName,
-            String buyerIdentifier,
             String buyerReference,
-            String sellerName,
+            PartySummary orderingCustomer,
+            PartySummary buyer,
+            PartySummary invoicee,
+            PartySummary payer,
+            PartySummary seller,
+            PartySummary shipTo,
             String currency,
             int lineCount,
+            MonetaryAmount orderNetTotal,
+            MonetaryAmount orderTaxTotal,
+            MonetaryAmount orderGrossTotal,
+            List<TaxSummary> orderTaxes,
             List<OrderLineSummary> lines) {
         this.orderId = orderId;
         this.issueDate = issueDate;
-        this.buyerName = buyerName;
-        this.buyerIdentifier = buyerIdentifier;
         this.buyerReference = buyerReference;
-        this.sellerName = sellerName;
+        this.orderingCustomer = orderingCustomer;
+        this.buyer = buyer;
+        this.invoicee = invoicee;
+        this.payer = payer;
+        this.seller = seller;
+        this.shipTo = shipTo;
         this.currency = currency;
         this.lineCount = lineCount;
-        this.lines = Collections.unmodifiableList(Objects.requireNonNull(lines, "lines"));
+        this.orderNetTotal = orderNetTotal;
+        this.orderTaxTotal = orderTaxTotal;
+        this.orderGrossTotal = orderGrossTotal;
+        List<TaxSummary> taxes = orderTaxes != null ? orderTaxes : List.of();
+        this.orderTaxes = Collections.unmodifiableList(new ArrayList<>(taxes));
+        this.lines = Collections.unmodifiableList(new ArrayList<>(Objects.requireNonNull(lines, "lines")));
     }
 
     public String getOrderId() {
@@ -49,20 +73,44 @@ public final class OrderAnalysisResult {
         return issueDate;
     }
 
-    public String getBuyerName() {
-        return buyerName;
-    }
-
-    public String getBuyerIdentifier() {
-        return buyerIdentifier;
-    }
-
     public String getBuyerReference() {
         return buyerReference;
     }
 
+    public PartySummary getOrderingCustomer() {
+        return orderingCustomer;
+    }
+
+    public PartySummary getBuyer() {
+        return buyer;
+    }
+
+    public PartySummary getInvoicee() {
+        return invoicee;
+    }
+
+    public PartySummary getPayer() {
+        return payer;
+    }
+
+    public PartySummary getSeller() {
+        return seller;
+    }
+
+    public PartySummary getShipTo() {
+        return shipTo;
+    }
+
+    public String getBuyerName() {
+        return buyer != null ? buyer.getName() : null;
+    }
+
+    public String getBuyerIdentifier() {
+        return buyer != null ? buyer.getIdentifier() : null;
+    }
+
     public String getSellerName() {
-        return sellerName;
+        return seller != null ? seller.getName() : null;
     }
 
     public String getCurrency() {
@@ -71,6 +119,22 @@ public final class OrderAnalysisResult {
 
     public int getLineCount() {
         return lineCount;
+    }
+
+    public MonetaryAmount getOrderNetTotal() {
+        return orderNetTotal;
+    }
+
+    public MonetaryAmount getOrderTaxTotal() {
+        return orderTaxTotal;
+    }
+
+    public MonetaryAmount getOrderGrossTotal() {
+        return orderGrossTotal;
+    }
+
+    public List<TaxSummary> getOrderTaxes() {
+        return orderTaxes;
     }
 
     public List<OrderLineSummary> getLines() {
@@ -91,32 +155,43 @@ public final class OrderAnalysisResult {
         if (issueDate != null && !issueDate.isBlank()) {
             sb.append("  Date d'émission : ").append(issueDate).append('\n');
         }
-        if ((buyerName != null && !buyerName.isBlank()) || (buyerIdentifier != null && !buyerIdentifier.isBlank())) {
-            sb.append("  Acheteur : ");
-            if (buyerName != null && !buyerName.isBlank()) {
-                sb.append(buyerName);
-            }
-            if (buyerIdentifier != null && !buyerIdentifier.isBlank()) {
-                if (buyerName != null && !buyerName.isBlank()) {
-                    sb.append(" (ID : ").append(buyerIdentifier).append(')');
-                } else {
-                    sb.append(buyerIdentifier);
-                }
-            }
-            sb.append('\n');
-        }
         if (buyerReference != null && !buyerReference.isBlank()) {
             sb.append("  Référence acheteur : ").append(buyerReference).append('\n');
         }
-        if (sellerName != null && !sellerName.isBlank()) {
-            sb.append("  Vendeur : ").append(sellerName).append('\n');
+        appendParty(sb, "Client commandeur", orderingCustomer);
+        appendParty(sb, "Acheteur", buyer);
+        appendParty(sb, "Facturé (invoicee)", invoicee);
+        if (!isSameParty(invoicee, payer)) {
+            appendParty(sb, "Payeur", payer);
         }
+        appendParty(sb, "Fournisseur", seller);
+        appendParty(sb, "Lieu de livraison", shipTo);
+
         if (currency != null && !currency.isBlank()) {
             sb.append("  Devise : ").append(currency).append('\n');
         }
+
+        boolean hasFinancialSummary = (orderNetTotal != null && orderNetTotal.getAmount() != null)
+                || (orderTaxTotal != null && orderTaxTotal.getAmount() != null)
+                || (orderGrossTotal != null && orderGrossTotal.getAmount() != null)
+                || !orderTaxes.isEmpty();
+        if (hasFinancialSummary) {
+            sb.append("  Synthèse montants :\n");
+            appendLabeledAmount(sb, "    • ", "Total HT", orderNetTotal);
+            appendLabeledAmount(sb, "    • ", "Total TVA", orderTaxTotal);
+            if (!orderTaxes.isEmpty()) {
+                sb.append("    • Détail TVA :\n");
+                appendTaxDetails(sb, "      ", orderTaxes);
+            }
+            appendLabeledAmount(sb, "    • ", "Total TTC", orderGrossTotal);
+        }
+
         sb.append("  Nombre de lignes : ").append(lineCount).append('\n');
 
         for (OrderLineSummary line : lines) {
+            if (line == null) {
+                continue;
+            }
             sb.append("    - Ligne ");
             if (line.getLineId() != null && !line.getLineId().isBlank()) {
                 sb.append(line.getLineId());
@@ -131,32 +206,131 @@ public final class OrderAnalysisResult {
             } else {
                 sb.append("Article sans nom");
             }
+            sb.append('\n');
+
             if (line.getQuantity() != null) {
-                sb.append(" — Quantité : ").append(line.getQuantity());
+                sb.append("      Quantité : ").append(formatNumber(line.getQuantity()));
                 if (line.getQuantityUnit() != null && !line.getQuantityUnit().isBlank()) {
                     sb.append(' ').append(line.getQuantityUnit());
                 }
+                sb.append('\n');
             }
-            if (line.getNetPrice() != null) {
-                sb.append(" — Prix unitaire : ")
-                        .append(line.getNetPrice());
-                if (line.getNetPriceCurrency() != null && !line.getNetPriceCurrency().isBlank()) {
-                    sb.append(' ').append(line.getNetPriceCurrency());
-                }
+            appendLabeledAmount(sb, "      ", "Prix unitaire HT", line.getNetUnitPrice());
+            appendLabeledAmount(sb, "      ", "Prix unitaire TTC", line.getGrossUnitPrice());
+            appendLabeledAmount(sb, "      ", "Total ligne HT", line.getLineNetAmount());
+            appendLabeledAmount(sb, "      ", "Total TVA", line.getLineTaxAmount());
+            if (!line.getTaxes().isEmpty()) {
+                sb.append("      TVA :\n");
+                appendTaxDetails(sb, "        ", line.getTaxes());
             }
-            if (line.getLineTotal() != null) {
-                sb.append(" — Total ligne : ")
-                        .append(line.getLineTotal());
-                String currencyCode = line.getLineTotalCurrency() != null && !line.getLineTotalCurrency().isBlank()
-                        ? line.getLineTotalCurrency()
-                        : currency;
-                if (currencyCode != null && !currencyCode.isBlank()) {
-                    sb.append(' ').append(currencyCode);
-                }
+            appendLabeledAmount(sb, "      ", "Total ligne TTC", line.getLineGrossAmount());
+        }
+        return sb.toString();
+    }
+
+    private static void appendParty(StringBuilder sb, String label, PartySummary party) {
+        if (party == null || party.isEmpty()) {
+            return;
+        }
+        sb.append("  ").append(label).append(" : ");
+        boolean hasName = party.getName() != null && !party.getName().isBlank();
+        if (hasName) {
+            sb.append(party.getName());
+        }
+        List<String> details = new ArrayList<>();
+        if (party.getIdentifier() != null && !party.getIdentifier().isBlank()) {
+            details.add("ID : " + party.getIdentifier());
+        }
+        if (party.getGlobalIdentifier() != null && !party.getGlobalIdentifier().isBlank()) {
+            details.add("GLN : " + party.getGlobalIdentifier());
+        }
+        if (!details.isEmpty()) {
+            if (hasName) {
+                sb.append(" (").append(String.join(", ", details)).append(')');
+            } else {
+                sb.append(String.join(", ", details));
+            }
+        }
+        sb.append('\n');
+    }
+
+    private static boolean isSameParty(PartySummary left, PartySummary right) {
+        if (left == right) {
+            return true;
+        }
+        if (left == null || right == null) {
+            return false;
+        }
+        return Objects.equals(left.getName(), right.getName())
+                && Objects.equals(left.getIdentifier(), right.getIdentifier())
+                && Objects.equals(left.getGlobalIdentifier(), right.getGlobalIdentifier());
+    }
+
+    private static void appendLabeledAmount(StringBuilder sb, String indent, String label, MonetaryAmount amount) {
+        if (amount == null || amount.getAmount() == null) {
+            return;
+        }
+        sb.append(indent).append(label).append(" : ").append(formatAmount(amount)).append('\n');
+    }
+
+    private static void appendTaxDetails(StringBuilder sb, String indent, List<TaxSummary> taxes) {
+        for (TaxSummary tax : taxes) {
+            if (tax == null) {
+                continue;
+            }
+            List<String> parts = new ArrayList<>();
+            if (tax.getRatePercent() != null) {
+                parts.add("Taux " + formatRate(tax.getRatePercent()));
+            }
+            if (tax.getBaseAmount() != null && tax.getBaseAmount().getAmount() != null) {
+                parts.add("Base : " + formatAmount(tax.getBaseAmount()));
+            }
+            if (tax.getTaxAmount() != null && tax.getTaxAmount().getAmount() != null) {
+                parts.add("Montant : " + formatAmount(tax.getTaxAmount()));
+            }
+            StringJoiner metadata = new StringJoiner(", ");
+            if (tax.getTypeCode() != null && !tax.getTypeCode().isBlank()) {
+                metadata.add("Type : " + tax.getTypeCode());
+            }
+            if (tax.getCategoryCode() != null && !tax.getCategoryCode().isBlank()) {
+                metadata.add("Catégorie : " + tax.getCategoryCode());
+            }
+            if (tax.getExemptionReason() != null && !tax.getExemptionReason().isBlank()) {
+                metadata.add("Motif : " + tax.getExemptionReason());
+            }
+            sb.append(indent).append("- ");
+            if (!parts.isEmpty()) {
+                sb.append(String.join(" — ", parts));
+            } else {
+                sb.append("Détail TVA indisponible");
+            }
+            if (metadata.length() > 0) {
+                sb.append(" [").append(metadata).append(']');
             }
             sb.append('\n');
         }
-        return sb.toString();
+    }
+
+    private static String formatAmount(MonetaryAmount amount) {
+        if (amount == null || amount.getAmount() == null) {
+            return "?";
+        }
+        BigDecimal value = amount.getAmount().stripTrailingZeros();
+        String text = value.scale() <= 0 ? value.toPlainString() : value.toPlainString();
+        if (amount.getCurrency() != null && !amount.getCurrency().isBlank()) {
+            text += " " + amount.getCurrency();
+        }
+        return text;
+    }
+
+    private static String formatRate(BigDecimal rate) {
+        BigDecimal normalized = rate.stripTrailingZeros();
+        return (normalized.scale() <= 0 ? normalized.toPlainString() : normalized.toPlainString()) + "%";
+    }
+
+    private static String formatNumber(BigDecimal number) {
+        BigDecimal normalized = number.stripTrailingZeros();
+        return normalized.scale() <= 0 ? normalized.toPlainString() : normalized.toPlainString();
     }
 
     @Override
@@ -173,10 +347,12 @@ public final class OrderAnalysisResult {
         private final String productName;
         private final BigDecimal quantity;
         private final String quantityUnit;
-        private final BigDecimal netPrice;
-        private final String netPriceCurrency;
-        private final BigDecimal lineTotal;
-        private final String lineTotalCurrency;
+        private final MonetaryAmount netUnitPrice;
+        private final MonetaryAmount grossUnitPrice;
+        private final MonetaryAmount lineNetAmount;
+        private final MonetaryAmount lineGrossAmount;
+        private final MonetaryAmount lineTaxAmount;
+        private final List<TaxSummary> taxes;
 
         public OrderLineSummary(
                 String lineId,
@@ -184,19 +360,24 @@ public final class OrderAnalysisResult {
                 String productName,
                 BigDecimal quantity,
                 String quantityUnit,
-                BigDecimal netPrice,
-                String netPriceCurrency,
-                BigDecimal lineTotal,
-                String lineTotalCurrency) {
+                MonetaryAmount netUnitPrice,
+                MonetaryAmount grossUnitPrice,
+                MonetaryAmount lineNetAmount,
+                MonetaryAmount lineGrossAmount,
+                MonetaryAmount lineTaxAmount,
+                List<TaxSummary> taxes) {
             this.lineId = lineId;
             this.productIdentifier = productIdentifier;
             this.productName = productName;
             this.quantity = quantity;
             this.quantityUnit = quantityUnit;
-            this.netPrice = netPrice;
-            this.netPriceCurrency = netPriceCurrency;
-            this.lineTotal = lineTotal;
-            this.lineTotalCurrency = lineTotalCurrency;
+            this.netUnitPrice = netUnitPrice;
+            this.grossUnitPrice = grossUnitPrice;
+            this.lineNetAmount = lineNetAmount;
+            this.lineGrossAmount = lineGrossAmount;
+            this.lineTaxAmount = lineTaxAmount;
+            List<TaxSummary> taxDetails = taxes != null ? taxes : List.of();
+            this.taxes = Collections.unmodifiableList(new ArrayList<>(taxDetails));
         }
 
         public String getLineId() {
@@ -219,20 +400,184 @@ public final class OrderAnalysisResult {
             return quantityUnit;
         }
 
+        public MonetaryAmount getNetUnitPrice() {
+            return netUnitPrice;
+        }
+
+        public MonetaryAmount getGrossUnitPrice() {
+            return grossUnitPrice;
+        }
+
+        public MonetaryAmount getLineNetAmount() {
+            return lineNetAmount;
+        }
+
+        public MonetaryAmount getLineGrossAmount() {
+            return lineGrossAmount;
+        }
+
+        public MonetaryAmount getLineTaxAmount() {
+            return lineTaxAmount;
+        }
+
+        public List<TaxSummary> getTaxes() {
+            return taxes;
+        }
+
+        /**
+         * @deprecated Utiliser {@link #getNetUnitPrice()}.
+         */
+        @Deprecated
         public BigDecimal getNetPrice() {
-            return netPrice;
+            return netUnitPrice != null ? netUnitPrice.getAmount() : null;
         }
 
+        /**
+         * @deprecated Utiliser {@link #getNetUnitPrice()}.
+         */
+        @Deprecated
         public String getNetPriceCurrency() {
-            return netPriceCurrency;
+            return netUnitPrice != null ? netUnitPrice.getCurrency() : null;
         }
 
+        /**
+         * @deprecated Utiliser {@link #getLineGrossAmount()} ou {@link #getLineNetAmount()}.
+         */
+        @Deprecated
         public BigDecimal getLineTotal() {
-            return lineTotal;
+            return lineGrossAmount != null ? lineGrossAmount.getAmount() : null;
         }
 
+        /**
+         * @deprecated Utiliser {@link #getLineGrossAmount()}.
+         */
+        @Deprecated
         public String getLineTotalCurrency() {
-            return lineTotalCurrency;
+            return lineGrossAmount != null ? lineGrossAmount.getCurrency() : null;
+        }
+    }
+
+    /**
+     * Représente un montant avec sa devise.
+     */
+    public static final class MonetaryAmount {
+        private final BigDecimal amount;
+        private final String currency;
+
+        public MonetaryAmount(BigDecimal amount, String currency) {
+            this.amount = amount;
+            this.currency = currency;
+        }
+
+        public BigDecimal getAmount() {
+            return amount;
+        }
+
+        public String getCurrency() {
+            return currency;
+        }
+    }
+
+    /**
+     * Détail d'une taxe (TVA).
+     */
+    public static final class TaxSummary {
+        private final String typeCode;
+        private final String categoryCode;
+        private final BigDecimal ratePercent;
+        private final MonetaryAmount baseAmount;
+        private final MonetaryAmount taxAmount;
+        private final String exemptionReason;
+
+        public TaxSummary(
+                String typeCode,
+                String categoryCode,
+                BigDecimal ratePercent,
+                MonetaryAmount baseAmount,
+                MonetaryAmount taxAmount,
+                String exemptionReason) {
+            this.typeCode = typeCode;
+            this.categoryCode = categoryCode;
+            this.ratePercent = ratePercent;
+            this.baseAmount = baseAmount;
+            this.taxAmount = taxAmount;
+            this.exemptionReason = exemptionReason;
+        }
+
+        public String getTypeCode() {
+            return typeCode;
+        }
+
+        public String getCategoryCode() {
+            return categoryCode;
+        }
+
+        public BigDecimal getRatePercent() {
+            return ratePercent;
+        }
+
+        public MonetaryAmount getBaseAmount() {
+            return baseAmount;
+        }
+
+        public MonetaryAmount getTaxAmount() {
+            return taxAmount;
+        }
+
+        public String getExemptionReason() {
+            return exemptionReason;
+        }
+    }
+
+    /**
+     * Résumé d'une partie prenante (client, fournisseur, payeur...).
+     */
+    public static final class PartySummary {
+        private final String name;
+        private final String identifier;
+        private final String globalIdentifier;
+
+        public PartySummary(String name, String identifier, String globalIdentifier) {
+            this.name = name;
+            this.identifier = identifier;
+            this.globalIdentifier = globalIdentifier;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getIdentifier() {
+            return identifier;
+        }
+
+        public String getGlobalIdentifier() {
+            return globalIdentifier;
+        }
+
+        public boolean isEmpty() {
+            return (name == null || name.isBlank())
+                    && (identifier == null || identifier.isBlank())
+                    && (globalIdentifier == null || globalIdentifier.isBlank());
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof PartySummary)) {
+                return false;
+            }
+            PartySummary that = (PartySummary) o;
+            return Objects.equals(name, that.name)
+                    && Objects.equals(identifier, that.identifier)
+                    && Objects.equals(globalIdentifier, that.globalIdentifier);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, identifier, globalIdentifier);
         }
     }
 }

--- a/cii-messaging-parent/cii-reader/src/test/java/com/cii/messaging/reader/analysis/OrderAnalyzerTest.java
+++ b/cii-messaging-parent/cii-reader/src/test/java/com/cii/messaging/reader/analysis/OrderAnalyzerTest.java
@@ -1,0 +1,116 @@
+package com.cii.messaging.reader.analysis;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OrderAnalyzerTest {
+
+    @Test
+    void shouldProduceDetailedSummary() throws Exception {
+        Path samplePath = resourcePath("/order-detailed-sample.xml");
+
+        OrderAnalysisResult result = OrderAnalyzer.analyserOrder(samplePath.toString());
+
+        assertNotNull(result);
+        assertEquals("ORD-DET-001", result.getOrderId());
+        assertEquals("DET-REF-001", result.getBuyerReference());
+
+        assertParty(result.getOrderingCustomer(), "Client Commandeur", "3300012399999");
+        assertParty(result.getBuyer(), "Acheteur Détaillé SAS", "3300012300002");
+        assertParty(result.getInvoicee(), "Société Facturée", "3300012300019");
+        assertParty(result.getPayer(), "Société Facturée", "3300012300019");
+        assertEquals(result.getInvoicee(), result.getPayer());
+        assertParty(result.getSeller(), "Fournisseur Démonstration SA", "5401234500008");
+        assertParty(result.getShipTo(), "Plateforme Logistique Client", "3300012390005");
+
+        assertMonetary(result.getOrderNetTotal(), "EUR", new BigDecimal("1000.00"));
+        assertMonetary(result.getOrderTaxTotal(), "EUR", new BigDecimal("200.00"));
+        assertMonetary(result.getOrderGrossTotal(), "EUR", new BigDecimal("1200.00"));
+
+        List<OrderAnalysisResult.OrderLineSummary> lines = result.getLines();
+        assertEquals(1, lines.size());
+
+        OrderAnalysisResult.OrderLineSummary line = lines.get(0);
+        assertEquals("1", line.getLineId());
+        assertEquals("Produit de démonstration", line.getProductName());
+        assertEquals(new BigDecimal("10"), line.getQuantity());
+        assertEquals("EA", line.getQuantityUnit());
+        assertMonetary(line.getNetUnitPrice(), "EUR", new BigDecimal("100.00"));
+        assertMonetary(line.getGrossUnitPrice(), "EUR", new BigDecimal("120.00"));
+        assertMonetary(line.getLineNetAmount(), "EUR", new BigDecimal("1000.00"));
+        assertMonetary(line.getLineTaxAmount(), "EUR", new BigDecimal("200.00"));
+        assertMonetary(line.getLineGrossAmount(), "EUR", new BigDecimal("1200.00"));
+        assertEquals(1, line.getTaxes().size());
+        OrderAnalysisResult.TaxSummary tax = line.getTaxes().get(0);
+        assertEquals("VAT", tax.getTypeCode());
+        assertEquals("S", tax.getCategoryCode());
+        assertEquals(new BigDecimal("20.00"), tax.getRatePercent());
+        assertMonetary(tax.getBaseAmount(), "EUR", new BigDecimal("1000.00"));
+        assertMonetary(tax.getTaxAmount(), "EUR", new BigDecimal("200.00"));
+
+        String pretty = result.toPrettyString();
+        assertTrue(pretty.contains("Client commandeur"));
+        assertTrue(pretty.contains("GLN : 3300012399999"));
+        assertTrue(pretty.contains("Facturé (invoicee)"));
+        assertTrue(pretty.contains("Lieu de livraison"));
+        assertTrue(pretty.contains("Prix unitaire HT : 100 EUR"));
+        assertTrue(pretty.contains("Total ligne TTC : 1200 EUR"));
+        assertTrue(pretty.contains("Taux 20%"));
+    }
+
+    @Test
+    void shouldComputeTotalsFromLinesWhenHeaderMissing() throws Exception {
+        Path samplePath = resourcePath("/order-missing-header-totals.xml");
+
+        OrderAnalysisResult result = OrderAnalyzer.analyserOrder(samplePath.toString());
+
+        assertNotNull(result);
+        assertEquals(2, result.getLineCount());
+        assertMonetary(result.getOrderNetTotal(), "EUR", new BigDecimal("250.00"));
+        assertMonetary(result.getOrderTaxTotal(), "EUR", new BigDecimal("35.00"));
+        assertMonetary(result.getOrderGrossTotal(), "EUR", new BigDecimal("285.00"));
+
+        List<OrderAnalysisResult.TaxSummary> orderTaxes = result.getOrderTaxes();
+        assertEquals(2, orderTaxes.size());
+
+        OrderAnalysisResult.TaxSummary first = orderTaxes.get(0);
+        assertEquals("VAT", first.getTypeCode());
+        assertEquals("S", first.getCategoryCode());
+        assertEquals(0, new BigDecimal("20").compareTo(first.getRatePercent()));
+        assertMonetary(first.getBaseAmount(), "EUR", new BigDecimal("100.00"));
+        assertMonetary(first.getTaxAmount(), "EUR", new BigDecimal("20.00"));
+
+        OrderAnalysisResult.TaxSummary second = orderTaxes.get(1);
+        assertEquals("VAT", second.getTypeCode());
+        assertEquals("AA", second.getCategoryCode());
+        assertEquals(0, new BigDecimal("10").compareTo(second.getRatePercent()));
+        assertMonetary(second.getBaseAmount(), "EUR", new BigDecimal("150.00"));
+        assertMonetary(second.getTaxAmount(), "EUR", new BigDecimal("15.00"));
+    }
+
+    private static void assertParty(OrderAnalysisResult.PartySummary party, String expectedName, String expectedGln) {
+        assertNotNull(party);
+        assertEquals(expectedName, party.getName());
+        assertEquals(expectedGln, party.getGlobalIdentifier());
+    }
+
+    private static void assertMonetary(OrderAnalysisResult.MonetaryAmount amount, String expectedCurrency, BigDecimal expectedValue) {
+        assertNotNull(amount, "Le montant ne doit pas être null");
+        assertEquals(expectedCurrency, amount.getCurrency());
+        assertEquals(0, expectedValue.compareTo(amount.getAmount()));
+    }
+
+    private static Path resourcePath(String resource) throws URISyntaxException {
+        var url = OrderAnalyzerTest.class.getResource(resource);
+        assertNotNull(url, "Ressource introuvable : " + resource);
+        return Path.of(url.toURI());
+    }
+}

--- a/cii-messaging-parent/cii-reader/src/test/resources/order-detailed-sample.xml
+++ b/cii-messaging-parent/cii-reader/src/test/resources/order-detailed-sample.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rsm:CrossIndustryOrder xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryOrder:100"
+                        xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+                        xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+    <rsm:ExchangedDocument>
+        <ram:ID>ORD-DET-001</ram:ID>
+        <ram:IssueDateTime>
+            <udt:DateTimeString format="102">20240315091500</udt:DateTimeString>
+        </ram:IssueDateTime>
+    </rsm:ExchangedDocument>
+    <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+            <ram:BuyerReference>DET-REF-001</ram:BuyerReference>
+            <ram:SellerTradeParty>
+                <ram:GlobalID schemeID="0088">5401234500008</ram:GlobalID>
+                <ram:Name>Fournisseur Démonstration SA</ram:Name>
+            </ram:SellerTradeParty>
+            <ram:BuyerTradeParty>
+                <ram:GlobalID schemeID="0088">3300012300002</ram:GlobalID>
+                <ram:Name>Acheteur Détaillé SAS</ram:Name>
+            </ram:BuyerTradeParty>
+            <ram:BuyerRequisitionerTradeParty>
+                <ram:GlobalID schemeID="0088">3300012399999</ram:GlobalID>
+                <ram:Name>Client Commandeur</ram:Name>
+            </ram:BuyerRequisitionerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+        <ram:ApplicableHeaderTradeDelivery>
+            <ram:ShipToTradeParty>
+                <ram:GlobalID schemeID="0088">3300012390005</ram:GlobalID>
+                <ram:Name>Plateforme Logistique Client</ram:Name>
+            </ram:ShipToTradeParty>
+        </ram:ApplicableHeaderTradeDelivery>
+        <ram:ApplicableHeaderTradeSettlement>
+            <ram:OrderCurrencyCode>EUR</ram:OrderCurrencyCode>
+            <ram:InvoiceeTradeParty>
+                <ram:GlobalID schemeID="0088">3300012300019</ram:GlobalID>
+                <ram:Name>Société Facturée</ram:Name>
+            </ram:InvoiceeTradeParty>
+            <ram:ApplicableTradeTax>
+                <ram:TypeCode>VAT</ram:TypeCode>
+                <ram:CategoryCode>S</ram:CategoryCode>
+                <ram:RateApplicablePercent>20.00</ram:RateApplicablePercent>
+                <ram:BasisAmount currencyID="EUR">1000.00</ram:BasisAmount>
+                <ram:CalculatedAmount currencyID="EUR">200.00</ram:CalculatedAmount>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+                <ram:TaxBasisTotalAmount currencyID="EUR">1000.00</ram:TaxBasisTotalAmount>
+                <ram:TaxTotalAmount currencyID="EUR">200.00</ram:TaxTotalAmount>
+                <ram:GrandTotalAmount currencyID="EUR">1200.00</ram:GrandTotalAmount>
+            </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        </ram:ApplicableHeaderTradeSettlement>
+        <ram:IncludedSupplyChainTradeLineItem>
+            <ram:AssociatedDocumentLineDocument>
+                <ram:LineID>1</ram:LineID>
+            </ram:AssociatedDocumentLineDocument>
+            <ram:SpecifiedTradeProduct>
+                <ram:GlobalID schemeID="GTIN">4012345678905</ram:GlobalID>
+                <ram:Name>Produit de démonstration</ram:Name>
+            </ram:SpecifiedTradeProduct>
+            <ram:SpecifiedLineTradeAgreement>
+                <ram:NetPriceProductTradePrice>
+                    <ram:ChargeAmount currencyID="EUR">100.00</ram:ChargeAmount>
+                </ram:NetPriceProductTradePrice>
+                <ram:GrossPriceProductTradePrice>
+                    <ram:ChargeAmount currencyID="EUR">120.00</ram:ChargeAmount>
+                </ram:GrossPriceProductTradePrice>
+            </ram:SpecifiedLineTradeAgreement>
+            <ram:SpecifiedLineTradeDelivery>
+                <ram:RequestedQuantity unitCode="EA">10</ram:RequestedQuantity>
+            </ram:SpecifiedLineTradeDelivery>
+            <ram:SpecifiedLineTradeSettlement>
+                <ram:ApplicableTradeTax>
+                    <ram:TypeCode>VAT</ram:TypeCode>
+                    <ram:CategoryCode>S</ram:CategoryCode>
+                    <ram:RateApplicablePercent>20.00</ram:RateApplicablePercent>
+                    <ram:BasisAmount currencyID="EUR">1000.00</ram:BasisAmount>
+                    <ram:CalculatedAmount currencyID="EUR">200.00</ram:CalculatedAmount>
+                </ram:ApplicableTradeTax>
+                <ram:SpecifiedTradeSettlementLineMonetarySummation>
+                    <ram:NetLineTotalAmount currencyID="EUR">1000.00</ram:NetLineTotalAmount>
+                    <ram:TaxTotalAmount currencyID="EUR">200.00</ram:TaxTotalAmount>
+                    <ram:GrandTotalAmount currencyID="EUR">1200.00</ram:GrandTotalAmount>
+                </ram:SpecifiedTradeSettlementLineMonetarySummation>
+            </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+    </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryOrder>

--- a/cii-messaging-parent/cii-reader/src/test/resources/order-missing-header-totals.xml
+++ b/cii-messaging-parent/cii-reader/src/test/resources/order-missing-header-totals.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rsm:CrossIndustryOrder xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryOrder:100"
+                        xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+                        xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+    <rsm:ExchangedDocument>
+        <ram:ID>ORD-LINES-001</ram:ID>
+        <ram:IssueDateTime>
+            <udt:DateTimeString format="102">20240401083000</udt:DateTimeString>
+        </ram:IssueDateTime>
+    </rsm:ExchangedDocument>
+    <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeAgreement>
+            <ram:SellerTradeParty>
+                <ram:GlobalID schemeID="0088">5401234500100</ram:GlobalID>
+                <ram:Name>Fournisseur Sans Somme</ram:Name>
+            </ram:SellerTradeParty>
+            <ram:BuyerTradeParty>
+                <ram:GlobalID schemeID="0088">3300012300107</ram:GlobalID>
+                <ram:Name>Acheteur Sans Somme</ram:Name>
+            </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+        <ram:ApplicableHeaderTradeSettlement>
+            <ram:OrderCurrencyCode>EUR</ram:OrderCurrencyCode>
+            <ram:PayerTradeParty>
+                <ram:GlobalID schemeID="0088">3300012300999</ram:GlobalID>
+                <ram:Name>Centre de Paiement</ram:Name>
+            </ram:PayerTradeParty>
+        </ram:ApplicableHeaderTradeSettlement>
+        <ram:IncludedSupplyChainTradeLineItem>
+            <ram:AssociatedDocumentLineDocument>
+                <ram:LineID>1</ram:LineID>
+            </ram:AssociatedDocumentLineDocument>
+            <ram:SpecifiedTradeProduct>
+                <ram:Name>Article TVA 20</ram:Name>
+            </ram:SpecifiedTradeProduct>
+            <ram:SpecifiedLineTradeDelivery>
+                <ram:RequestedQuantity unitCode="EA">5</ram:RequestedQuantity>
+            </ram:SpecifiedLineTradeDelivery>
+            <ram:SpecifiedLineTradeSettlement>
+                <ram:ApplicableTradeTax>
+                    <ram:TypeCode>VAT</ram:TypeCode>
+                    <ram:CategoryCode>S</ram:CategoryCode>
+                    <ram:RateApplicablePercent>20.0</ram:RateApplicablePercent>
+                    <ram:BasisAmount currencyID="EUR">100.00</ram:BasisAmount>
+                    <ram:CalculatedAmount currencyID="EUR">20.00</ram:CalculatedAmount>
+                </ram:ApplicableTradeTax>
+                <ram:SpecifiedTradeSettlementLineMonetarySummation>
+                    <ram:NetLineTotalAmount currencyID="EUR">100.00</ram:NetLineTotalAmount>
+                    <ram:TaxTotalAmount currencyID="EUR">20.00</ram:TaxTotalAmount>
+                    <ram:GrandTotalAmount currencyID="EUR">120.00</ram:GrandTotalAmount>
+                </ram:SpecifiedTradeSettlementLineMonetarySummation>
+            </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+        <ram:IncludedSupplyChainTradeLineItem>
+            <ram:AssociatedDocumentLineDocument>
+                <ram:LineID>2</ram:LineID>
+            </ram:AssociatedDocumentLineDocument>
+            <ram:SpecifiedTradeProduct>
+                <ram:Name>Article TVA 10</ram:Name>
+            </ram:SpecifiedTradeProduct>
+            <ram:SpecifiedLineTradeDelivery>
+                <ram:RequestedQuantity unitCode="EA">3</ram:RequestedQuantity>
+            </ram:SpecifiedLineTradeDelivery>
+            <ram:SpecifiedLineTradeSettlement>
+                <ram:ApplicableTradeTax>
+                    <ram:TypeCode>VAT</ram:TypeCode>
+                    <ram:CategoryCode>AA</ram:CategoryCode>
+                    <ram:RateApplicablePercent>10.00</ram:RateApplicablePercent>
+                    <ram:BasisAmount currencyID="EUR">150.00</ram:BasisAmount>
+                    <ram:CalculatedAmount currencyID="EUR">15.00</ram:CalculatedAmount>
+                </ram:ApplicableTradeTax>
+                <ram:SpecifiedTradeSettlementLineMonetarySummation>
+                    <ram:NetLineTotalAmount currencyID="EUR">150.00</ram:NetLineTotalAmount>
+                    <ram:TaxTotalAmount currencyID="EUR">15.00</ram:TaxTotalAmount>
+                    <ram:GrandTotalAmount currencyID="EUR">165.00</ram:GrandTotalAmount>
+                </ram:SpecifiedTradeSettlementLineMonetarySummation>
+            </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+    </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryOrder>


### PR DESCRIPTION
## Summary
- expose invoicee and ship-to parties in the order analysis result and pretty-printed summary, deduplicating payer details
- compute header totals and VAT breakdowns from line data when missing, aggregating line-level taxes
- extend analyzer coverage with updated detailed sample and a missing-header sample to validate the richer summary

## Testing
- mvn -pl cii-reader -am test

------
https://chatgpt.com/codex/tasks/task_e_68cd1bb98570832eb5e1a322b8421a01