### PR TITLE
Fix header totals extraction for order analysis

### DIFF
--- a/cii-messaging-parent/cii-reader/src/test/java/com/cii/messaging/reader/analysis/OrderAnalyzerTest.java
+++ b/cii-messaging-parent/cii-reader/src/test/java/com/cii/messaging/reader/analysis/OrderAnalyzerTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class OrderAnalyzerTest {
@@ -94,6 +95,19 @@ class OrderAnalyzerTest {
         assertEquals(0, new BigDecimal("10").compareTo(second.getRatePercent()));
         assertMonetary(second.getBaseAmount(), "EUR", new BigDecimal("150.00"));
         assertMonetary(second.getTaxAmount(), "EUR", new BigDecimal("15.00"));
+    }
+
+    @Test
+    void shouldFallbackToLineTotalWhenTaxBasisZero() throws Exception {
+        Path samplePath = resourcePath("/order-header-line-total-only.xml");
+
+        OrderAnalysisResult result = OrderAnalyzer.analyserOrder(samplePath.toString());
+
+        assertNotNull(result);
+        assertMonetary(result.getOrderNetTotal(), "EUR", new BigDecimal("297.53"));
+        assertNull(result.getOrderTaxTotal(), "Le total TVA doit être absent lorsqu'aucune taxe n'est fournie");
+        assertMonetary(result.getOrderGrossTotal(), "EUR", new BigDecimal("297.53"));
+        assertTrue(result.getOrderTaxes().isEmpty());
     }
 
     private static void assertParty(OrderAnalysisResult.PartySummary party, String expectedName, String expectedGln) {

--- a/cii-messaging-parent/cii-reader/src/test/resources/order-header-line-total-only.xml
+++ b/cii-messaging-parent/cii-reader/src/test/resources/order-header-line-total-only.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rsm:CrossIndustryOrder xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryOrder:100"
+                        xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+                        xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+    <rsm:ExchangedDocument>
+        <ram:ID>ORD-LINE-TOTAL-ONLY</ram:ID>
+    </rsm:ExchangedDocument>
+    <rsm:SupplyChainTradeTransaction>
+        <ram:ApplicableHeaderTradeSettlement>
+            <ram:OrderCurrencyCode>EUR</ram:OrderCurrencyCode>
+            <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+                <ram:LineTotalAmount currencyID="EUR">297.53</ram:LineTotalAmount>
+                <ram:TaxBasisTotalAmount currencyID="EUR">0.00</ram:TaxBasisTotalAmount>
+            </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        </ram:ApplicableHeaderTradeSettlement>
+        <ram:IncludedSupplyChainTradeLineItem>
+            <ram:AssociatedDocumentLineDocument>
+                <ram:LineID>1</ram:LineID>
+            </ram:AssociatedDocumentLineDocument>
+            <ram:SpecifiedLineTradeAgreement>
+                <ram:NetPriceProductTradePrice>
+                    <ram:ChargeAmount currencyID="EUR">20.00</ram:ChargeAmount>
+                </ram:NetPriceProductTradePrice>
+            </ram:SpecifiedLineTradeAgreement>
+            <ram:SpecifiedLineTradeDelivery>
+                <ram:RequestedQuantity unitCode="EA">5</ram:RequestedQuantity>
+            </ram:SpecifiedLineTradeDelivery>
+            <ram:SpecifiedLineTradeSettlement>
+                <ram:SpecifiedTradeSettlementLineMonetarySummation>
+                    <ram:LineTotalAmount currencyID="EUR">100.00</ram:LineTotalAmount>
+                </ram:SpecifiedTradeSettlementLineMonetarySummation>
+            </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+        <ram:IncludedSupplyChainTradeLineItem>
+            <ram:AssociatedDocumentLineDocument>
+                <ram:LineID>2</ram:LineID>
+            </ram:AssociatedDocumentLineDocument>
+            <ram:SpecifiedLineTradeAgreement>
+                <ram:NetPriceProductTradePrice>
+                    <ram:ChargeAmount currencyID="EUR">33.61</ram:ChargeAmount>
+                </ram:NetPriceProductTradePrice>
+            </ram:SpecifiedLineTradeAgreement>
+            <ram:SpecifiedLineTradeDelivery>
+                <ram:RequestedQuantity unitCode="EA">5.872</ram:RequestedQuantity>
+            </ram:SpecifiedLineTradeDelivery>
+            <ram:SpecifiedLineTradeSettlement>
+                <ram:SpecifiedTradeSettlementLineMonetarySummation>
+                    <ram:LineTotalAmount currencyID="EUR">197.53</ram:LineTotalAmount>
+                </ram:SpecifiedTradeSettlementLineMonetarySummation>
+            </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+    </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryOrder>


### PR DESCRIPTION
## Summary
- ensure order header totals prefer NetLineTotal/LineTotal values and add fallbacks when no taxes are provided
- add safeguards to avoid treating missing tax data as significant and derive gross totals from net amounts when appropriate
- cover line-total-only scenarios with a dedicated XML sample and regression test

## Testing
- mvn -pl cii-reader -am test

------
https://chatgpt.com/codex/tasks/task_e_68cd44b3cc34832e97a5aa114b5fb829