### PR TITLE
Add ORDER_RESPONSE generation feature and CLI respond command

### DIFF
--- a/cii-messaging-parent/README.md
+++ b/cii-messaging-parent/README.md
@@ -124,6 +124,22 @@ Valide un document CII selon les schémas UNECE et les règles métier.
 Le validateur affiche un résumé concis (validité, nombre d’erreurs, bundle de schémas utilisé, temps d’exécution)
 et liste chaque erreur et avertissement individuellement.
 
+### Commande `respond`
+
+Génère automatiquement un ORDER_RESPONSE (ORDERSP) à partir d’un ORDER existant.
+
+| Paramètre ou option | Description | Valeur par défaut |
+|---------------------|-------------|-------------------|
+| `INPUT` (paramètre) | Fichier ORDER XML source | — |
+| `-o, --output <FILE>` | Fichier ORDER_RESPONSE à produire | `<INPUT>-ordersp.xml` dans le même dossier |
+| `--response-id <ID>` | Identifiant explicite du document ORDER_RESPONSE | Préfixe + ID de l’ORDER |
+| `--response-id-prefix <PREFIX>` | Préfixe utilisé pour générer l’ID si aucun n’est fourni | `ORDRSP-` |
+| `--ack-code <CODE>` | Code d’accusé de réception (AP=Accepté, RE=Rejeté, …) | `AP` |
+| `--issue-date <yyyyMMddHHmmss>` | Date d’émission forcée | Date courante |
+
+La commande lit le message ORDER, reconstruit les entêtes (parties, montants, lignes) et produit un ORDER_RESPONSE
+cohérent avec les quantités demandées.
+
 ## 🧪 Exemples en ligne de commande
 
 En supposant que le JAR assemblé a été construit (`mvn -pl cii-cli -am clean package`) :

--- a/cii-messaging-parent/cii-cli/pom.xml
+++ b/cii-messaging-parent/cii-cli/pom.xml
@@ -38,6 +38,11 @@
         </dependency>
         <dependency>
             <groupId>com.cii.messaging</groupId>
+            <artifactId>cii-writer</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.cii.messaging</groupId>
             <artifactId>cii-validator</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/CIIMessagingCLI.java
+++ b/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/CIIMessagingCLI.java
@@ -17,7 +17,8 @@ import java.util.Optional;
     },
     subcommands = {
         ParseCommand.class,
-        ValidateCommand.class
+        ValidateCommand.class,
+        RespondCommand.class
     }
 )
 public class CIIMessagingCLI extends AbstractCommand implements Runnable {

--- a/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/RespondCommand.java
+++ b/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/RespondCommand.java
@@ -1,0 +1,115 @@
+package com.cii.messaging.cli;
+
+import com.cii.messaging.model.order.Order;
+import com.cii.messaging.reader.OrderReader;
+import com.cii.messaging.reader.CIIReaderException;
+import com.cii.messaging.writer.CIIWriterException;
+import com.cii.messaging.writer.generation.OrderResponseGenerationOptions;
+import com.cii.messaging.writer.generation.OrderResponseGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.concurrent.Callable;
+
+/**
+ * Commande CLI générant automatiquement un ORDER_RESPONSE (ORDERSP) depuis un fichier ORDER.
+ */
+@Command(name = "respond", description = "Générer un ORDER_RESPONSE (ORDERSP) à partir d'un message ORDER")
+public class RespondCommand extends AbstractCommand implements Callable<Integer> {
+
+    private static final Logger logger = LoggerFactory.getLogger(RespondCommand.class);
+    private static final DateTimeFormatter ISSUE_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+
+    @Parameters(index = "0", paramLabel = "INPUT", description = "Fichier ORDER XML d'entrée")
+    private Path inputFile;
+
+    @Option(names = {"-o", "--output"}, paramLabel = "FILE", description = "Fichier ORDER_RESPONSE de sortie")
+    private Path outputFile;
+
+    @Option(names = "--response-id", description = "Identifiant explicite du ORDER_RESPONSE généré")
+    private String responseId;
+
+    @Option(names = "--ack-code", description = "Code d'accusé de réception (ex: AP, RE)", defaultValue = "AP")
+    private String acknowledgementCode = "AP";
+
+    @Option(names = "--issue-date", description = "Date d'émission au format yyyyMMddHHmmss")
+    private String issueDate;
+
+    @Option(names = "--response-id-prefix", description = "Préfixe appliqué à l'identifiant si non fourni", defaultValue = "ORDRSP-")
+    private String responseIdPrefix = "ORDRSP-";
+
+    @Override
+    public Integer call() {
+        configureLogging();
+
+        Path resolvedInput = inputFile.toAbsolutePath().normalize();
+        if (!Files.exists(resolvedInput) || !Files.isRegularFile(resolvedInput)) {
+            logger.error("Fichier d'entrée introuvable : {}", resolvedInput);
+            return 1;
+        }
+        if (!Files.isReadable(resolvedInput)) {
+            logger.error("Fichier d'entrée illisible : {}", resolvedInput);
+            return 1;
+        }
+
+        Path resolvedOutput = resolveOutputPath(resolvedInput);
+
+        try {
+            Order order = new OrderReader().read(resolvedInput.toFile());
+            OrderResponseGenerationOptions options = buildOptions();
+            String message = OrderResponseGenerator.genererOrderResponse(order, resolvedOutput.toString(), options);
+            logger.info(message);
+            return 0;
+        } catch (CIIReaderException e) {
+            logger.error("Impossible de lire le fichier ORDER : {}", e.getMessage());
+            logger.debug("Erreur complète", e);
+            return 1;
+        } catch (DateTimeParseException e) {
+            logger.error("Format de date invalide pour --issue-date (attendu yyyyMMddHHmmss) : {}", e.getParsedString());
+            return 1;
+        } catch (IOException | CIIWriterException e) {
+            logger.error("Erreur lors de la génération du ORDER_RESPONSE : {}", e.getMessage());
+            logger.debug("Erreur complète", e);
+            return 1;
+        }
+    }
+
+    private OrderResponseGenerationOptions buildOptions() {
+        OrderResponseGenerationOptions.Builder builder = OrderResponseGenerationOptions.builder()
+                .withResponseIdPrefix(responseIdPrefix)
+                .withAcknowledgementCode(acknowledgementCode);
+
+        if (responseId != null && !responseId.isBlank()) {
+            builder.withResponseId(responseId.trim());
+        }
+        if (issueDate != null && !issueDate.isBlank()) {
+            builder.withIssueDateTime(LocalDateTime.parse(issueDate.trim(), ISSUE_DATE_FORMAT));
+        }
+        return builder.build();
+    }
+
+    private Path resolveOutputPath(Path resolvedInput) {
+        if (outputFile != null) {
+            return outputFile.toAbsolutePath().normalize();
+        }
+        String fileName = resolvedInput.getFileName().toString();
+        int dotIndex = fileName.lastIndexOf('.');
+        String base = dotIndex >= 0 ? fileName.substring(0, dotIndex) : fileName;
+        String extension = dotIndex >= 0 ? fileName.substring(dotIndex) : ".xml";
+        String targetName = base + "-ordersp" + extension;
+        Path parent = resolvedInput.getParent();
+        if (parent == null) {
+            parent = Path.of(".");
+        }
+        return parent.resolve(targetName).toAbsolutePath().normalize();
+    }
+}

--- a/cii-messaging-parent/cii-cli/src/test/java/com/cii/messaging/cli/RespondCommandTest.java
+++ b/cii-messaging-parent/cii-cli/src/test/java/com/cii/messaging/cli/RespondCommandTest.java
@@ -1,0 +1,78 @@
+package com.cii.messaging.cli;
+
+import com.cii.messaging.reader.OrderResponseReader;
+import com.cii.messaging.reader.CIIReaderException;
+import com.cii.messaging.model.orderresponse.OrderResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RespondCommandTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void genereOrderResponseDansFichierSpecifie() throws Exception {
+        Path input = copierEchantillon("/order-sample.xml");
+        Path output = tempDir.resolve("ordersp.xml");
+
+        int exitCode = new CommandLine(new RespondCommand()).execute(
+                input.toString(),
+                "--output", output.toString(),
+                "--ack-code", "RE",
+                "--issue-date", "20240305120000"
+        );
+
+        assertThat(exitCode).isZero();
+        assertThat(output).exists();
+
+        OrderResponse response = lireOrderResponse(output);
+        assertThat(response.getExchangedDocument().getID().getValue()).isEqualTo("ORDRSP-ORD-2024-001");
+        assertThat(response.getExchangedDocument().getStatusCode().getValue()).isEqualTo("RE");
+        assertThat(response.getSupplyChainTradeTransaction().getIncludedSupplyChainTradeLineItem()).hasSize(2);
+        assertThat(response.getSupplyChainTradeTransaction().getIncludedSupplyChainTradeLineItem().get(0)
+                .getSpecifiedLineTradeDelivery().getAgreedQuantity().getValue()).isEqualByComparingTo("100");
+    }
+
+    @Test
+    void genereFichierParDefautDansMemeDossier() throws Exception {
+        Path input = copierEchantillon("/order-sample.xml");
+
+        int exitCode = new CommandLine(new RespondCommand()).execute(
+                input.toString(),
+                "--issue-date", "20240305120000"
+        );
+
+        assertThat(exitCode).isZero();
+        Path expected = input.getParent().resolve("order-sample-ordersp.xml");
+        assertThat(expected).exists();
+    }
+
+    @Test
+    void renvoieErreurSiFichierManquant() {
+        Path missing = tempDir.resolve("missing.xml");
+
+        int exitCode = new CommandLine(new RespondCommand()).execute(missing.toString());
+
+        assertThat(exitCode).isNotZero();
+    }
+
+    private Path copierEchantillon(String resource) throws IOException, URISyntaxException {
+        Path source = Path.of(getClass().getResource(resource).toURI());
+        Path target = tempDir.resolve(Path.of(resource).getFileName());
+        Files.copy(source, target);
+        return target;
+    }
+
+    private OrderResponse lireOrderResponse(Path path) throws CIIReaderException {
+        return new OrderResponseReader().read(path.toFile());
+    }
+}

--- a/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/OrderResponseGenerationOptions.java
+++ b/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/OrderResponseGenerationOptions.java
@@ -1,0 +1,193 @@
+package com.cii.messaging.writer.generation;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+/**
+ * Configuration immuable dédiée à la génération d'un message ORDER_RESPONSE à partir d'un ORDER.
+ */
+public final class OrderResponseGenerationOptions {
+
+    private final String responseId;
+    private final String responseIdPrefix;
+    private final String acknowledgementCode;
+    private final String documentTypeCode;
+    private final LocalDateTime issueDateTime;
+    private final Clock clock;
+
+    private OrderResponseGenerationOptions(Builder builder) {
+        this.responseId = builder.responseId;
+        this.responseIdPrefix = builder.responseIdPrefix;
+        this.acknowledgementCode = builder.acknowledgementCode;
+        this.documentTypeCode = builder.documentTypeCode;
+        this.issueDateTime = builder.issueDateTime;
+        this.clock = builder.clock;
+    }
+
+    /**
+     * Crée un jeu d'options avec les valeurs par défaut.
+     *
+     * @return les options avec horloge système et identifiants par défaut
+     */
+    public static OrderResponseGenerationOptions defaults() {
+        return builder().build();
+    }
+
+    /**
+     * Démarre la construction d'options personnalisées.
+     *
+     * @return un builder initialisé avec les valeurs par défaut
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Identifiant explicite du document ORDER_RESPONSE à générer.
+     *
+     * @return identifiant fixe ou {@code null} si un préfixe doit être appliqué
+     */
+    public String getResponseId() {
+        return responseId;
+    }
+
+    /**
+     * Préfixe utilisé pour dériver l'identifiant lorsque {@link #getResponseId()} est nul.
+     *
+     * @return préfixe non nul
+     */
+    public String getResponseIdPrefix() {
+        return responseIdPrefix;
+    }
+
+    /**
+     * Code d'accusé de réception à positionner dans le document (ex. {@code AP}).
+     *
+     * @return code d'accusé de réception non nul
+     */
+    public String getAcknowledgementCode() {
+        return acknowledgementCode;
+    }
+
+    /**
+     * Code de type de document à positionner (ex. {@code 231} pour ORDER_RESPONSE).
+     *
+     * @return code non nul
+     */
+    public String getDocumentTypeCode() {
+        return documentTypeCode;
+    }
+
+    /**
+     * Date d'émission explicite. Si {@code null}, l'horloge est utilisée.
+     *
+     * @return date d'émission souhaitée ou {@code null}
+     */
+    public LocalDateTime getIssueDateTime() {
+        return issueDateTime;
+    }
+
+    /**
+     * Horloge utilisée pour dériver la date d'émission lorsque {@link #getIssueDateTime()} est nulle.
+     *
+     * @return horloge non nulle
+     */
+    public Clock getClock() {
+        return clock;
+    }
+
+    /**
+     * Builder fluide pour {@link OrderResponseGenerationOptions}.
+     */
+    public static final class Builder {
+        private String responseId;
+        private String responseIdPrefix = "ORDRSP-";
+        private String acknowledgementCode = "AP";
+        private String documentTypeCode = "231";
+        private LocalDateTime issueDateTime;
+        private Clock clock = Clock.systemUTC();
+
+        private Builder() {
+        }
+
+        /**
+         * Définit un identifiant fixe pour la réponse.
+         *
+         * @param responseId identifiant souhaité
+         * @return builder pour chaînage
+         */
+        public Builder withResponseId(String responseId) {
+            this.responseId = responseId;
+            return this;
+        }
+
+        /**
+         * Personnalise le préfixe utilisé pour générer l'identifiant.
+         *
+         * @param responseIdPrefix préfixe non vide
+         * @return builder pour chaînage
+         */
+        public Builder withResponseIdPrefix(String responseIdPrefix) {
+            this.responseIdPrefix = Objects.requireNonNull(responseIdPrefix, "responseIdPrefix");
+            return this;
+        }
+
+        /**
+         * Personnalise le code d'accusé de réception.
+         *
+         * @param acknowledgementCode code non vide
+         * @return builder pour chaînage
+         */
+        public Builder withAcknowledgementCode(String acknowledgementCode) {
+            this.acknowledgementCode = Objects.requireNonNull(acknowledgementCode, "acknowledgementCode");
+            return this;
+        }
+
+        /**
+         * Personnalise le code de type de document.
+         *
+         * @param documentTypeCode code non vide
+         * @return builder pour chaînage
+         */
+        public Builder withDocumentTypeCode(String documentTypeCode) {
+            this.documentTypeCode = Objects.requireNonNull(documentTypeCode, "documentTypeCode");
+            return this;
+        }
+
+        /**
+         * Force la date/heure d'émission à utiliser.
+         *
+         * @param issueDateTime date explicite
+         * @return builder pour chaînage
+         */
+        public Builder withIssueDateTime(LocalDateTime issueDateTime) {
+            this.issueDateTime = issueDateTime;
+            return this;
+        }
+
+        /**
+         * Spécifie l'horloge pour les calculs de date par défaut.
+         *
+         * @param clock horloge non nulle
+         * @return builder pour chaînage
+         */
+        public Builder withClock(Clock clock) {
+            this.clock = Objects.requireNonNull(clock, "clock");
+            return this;
+        }
+
+        /**
+         * Construit l'instance immuable.
+         *
+         * @return options configurées
+         */
+        public OrderResponseGenerationOptions build() {
+            Objects.requireNonNull(responseIdPrefix, "responseIdPrefix");
+            Objects.requireNonNull(acknowledgementCode, "acknowledgementCode");
+            Objects.requireNonNull(documentTypeCode, "documentTypeCode");
+            Objects.requireNonNull(clock, "clock");
+            return new OrderResponseGenerationOptions(this);
+        }
+    }
+}

--- a/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/OrderResponseGenerator.java
+++ b/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/OrderResponseGenerator.java
@@ -1,0 +1,608 @@
+package com.cii.messaging.writer.generation;
+
+import com.cii.messaging.model.order.Order;
+import com.cii.messaging.model.orderresponse.OrderResponse;
+import com.cii.messaging.unece.orderresponse.AmountType;
+import com.cii.messaging.unece.orderresponse.CodeType;
+import com.cii.messaging.unece.orderresponse.CurrencyCodeType;
+import com.cii.messaging.unece.orderresponse.DateTimeType;
+import com.cii.messaging.unece.orderresponse.DocumentCodeType;
+import com.cii.messaging.unece.orderresponse.DocumentContextParameterType;
+import com.cii.messaging.unece.orderresponse.DocumentLineDocumentType;
+import com.cii.messaging.unece.orderresponse.DocumentStatusCodeType;
+import com.cii.messaging.unece.orderresponse.ExchangedDocumentContextType;
+import com.cii.messaging.unece.orderresponse.ExchangedDocumentType;
+import com.cii.messaging.unece.orderresponse.HeaderTradeAgreementType;
+import com.cii.messaging.unece.orderresponse.HeaderTradeDeliveryType;
+import com.cii.messaging.unece.orderresponse.HeaderTradeSettlementType;
+import com.cii.messaging.unece.orderresponse.IDType;
+import com.cii.messaging.unece.orderresponse.LineTradeDeliveryType;
+import com.cii.messaging.unece.orderresponse.QuantityType;
+import com.cii.messaging.unece.orderresponse.ReferencedDocumentType;
+import com.cii.messaging.unece.orderresponse.SupplyChainTradeLineItemType;
+import com.cii.messaging.unece.orderresponse.SupplyChainTradeTransactionType;
+import com.cii.messaging.unece.orderresponse.TextType;
+import com.cii.messaging.unece.orderresponse.TradeAddressType;
+import com.cii.messaging.unece.orderresponse.TradePartyType;
+import com.cii.messaging.unece.orderresponse.TradeProductType;
+import com.cii.messaging.unece.orderresponse.TradeSettlementHeaderMonetarySummationType;
+import com.cii.messaging.writer.CIIWriterException;
+import com.cii.messaging.writer.OrderResponseWriter;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Transforme un message ORDERS en ORDER_RESPONSE structuré conformément aux schémas UNECE.
+ */
+public final class OrderResponseGenerator {
+
+    private static final DateTimeFormatter ISSUE_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+
+    private OrderResponseGenerator() {
+        // utilitaire
+    }
+
+    /**
+     * Génère un ORDER_RESPONSE à partir de l'ORDER fourni en appliquant les options par défaut.
+     *
+     * @param order commande source
+     * @return réponse construite
+     */
+    public static OrderResponse genererDepuisOrder(Order order) {
+        return genererDepuisOrder(order, OrderResponseGenerationOptions.defaults());
+    }
+
+    /**
+     * Génère un ORDER_RESPONSE à partir de l'ORDER fourni.
+     *
+     * @param order   commande source
+     * @param options options de génération (peut être {@code null} pour les valeurs par défaut)
+     * @return réponse structurée prête à être sérialisée
+     */
+    public static OrderResponse genererDepuisOrder(Order order, OrderResponseGenerationOptions options) {
+        Objects.requireNonNull(order, "order");
+        OrderResponseGenerationOptions resolved = options != null ? options : OrderResponseGenerationOptions.defaults();
+
+        String orderId = extractOrderId(order);
+        LocalDateTime issueDate = resolveIssueDate(resolved);
+        String responseId = resolveResponseId(orderId, resolved, issueDate);
+
+        Mapper mapper = new Mapper(order, orderId);
+        return mapper.map(responseId, issueDate, resolved);
+    }
+
+    /**
+     * Génère puis écrit un ORDER_RESPONSE au format XML sur le chemin souhaité.
+     *
+     * @param order        commande source
+     * @param cheminSortie chemin du fichier ORDER_RESPONSE à produire
+     * @param options      options de génération (peut être {@code null})
+     * @return message de confirmation avec le chemin absolu du fichier produit
+     * @throws IOException        si l'écriture échoue ou si le chemin est invalide
+     * @throws CIIWriterException si la sérialisation JAXB échoue
+     */
+    public static String genererOrderResponse(Order order, String cheminSortie, OrderResponseGenerationOptions options)
+            throws IOException, CIIWriterException {
+        Objects.requireNonNull(order, "order");
+        Objects.requireNonNull(cheminSortie, "cheminSortie");
+
+        Path outputPath = Path.of(cheminSortie);
+        Path parent = outputPath.toAbsolutePath().getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+        if (Files.exists(outputPath) && Files.isDirectory(outputPath)) {
+            throw new IOException("Le chemin de sortie correspond à un répertoire : " + cheminSortie);
+        }
+
+        OrderResponse response = genererDepuisOrder(order, options);
+        new OrderResponseWriter().write(response, outputPath.toFile());
+        return "Fichier ORDER_RESPONSE généré avec succès : " + outputPath.toAbsolutePath();
+    }
+
+    private static String extractOrderId(Order order) {
+        if (order.getExchangedDocument() != null && order.getExchangedDocument().getID() != null) {
+            return order.getExchangedDocument().getID().getValue();
+        }
+        return null;
+    }
+
+    private static LocalDateTime resolveIssueDate(OrderResponseGenerationOptions options) {
+        return options.getIssueDateTime() != null ? options.getIssueDateTime() : LocalDateTime.now(options.getClock());
+    }
+
+    private static String resolveResponseId(String orderId, OrderResponseGenerationOptions options, LocalDateTime issueDate) {
+        if (options.getResponseId() != null && !options.getResponseId().isBlank()) {
+            return options.getResponseId().trim();
+        }
+        if (orderId != null && !orderId.isBlank()) {
+            return options.getResponseIdPrefix() + orderId.trim();
+        }
+        return options.getResponseIdPrefix() + ISSUE_DATE_FORMATTER.format(issueDate);
+    }
+
+    /**
+     * Réalise l'intégralité du mapping entre les structures ORDER et ORDER_RESPONSE.
+     */
+    private static final class Mapper {
+        private final Order source;
+        private final String orderId;
+
+        private Mapper(Order source, String orderId) {
+            this.source = source;
+            this.orderId = orderId;
+        }
+
+        private OrderResponse map(String responseId, LocalDateTime issueDate, OrderResponseGenerationOptions options) {
+            OrderResponse response = new OrderResponse();
+            response.setExchangedDocumentContext(mapContext());
+            response.setExchangedDocument(mapDocument(responseId, issueDate, options));
+            response.setSupplyChainTradeTransaction(mapTransaction());
+            return response;
+        }
+
+        private ExchangedDocumentContextType mapContext() {
+            ExchangedDocumentContextType target = new ExchangedDocumentContextType();
+            com.cii.messaging.unece.order.ExchangedDocumentContextType sourceContext = source.getExchangedDocumentContext();
+            if (sourceContext == null) {
+                return target;
+            }
+
+            target.setSpecifiedTransactionID(copyId(sourceContext.getSpecifiedTransactionID()));
+            target.setTestIndicator(copyIndicator(sourceContext.getTestIndicator()));
+            target.setProcessingTransactionDateTime(copyDateTime(sourceContext.getProcessingTransactionDateTime()));
+
+            copyDocumentContextParameters(sourceContext.getBusinessProcessSpecifiedDocumentContextParameter(),
+                    target.getBusinessProcessSpecifiedDocumentContextParameter());
+            copyDocumentContextParameters(sourceContext.getBIMSpecifiedDocumentContextParameter(),
+                    target.getBIMSpecifiedDocumentContextParameter());
+            copyDocumentContextParameters(sourceContext.getScenarioSpecifiedDocumentContextParameter(),
+                    target.getScenarioSpecifiedDocumentContextParameter());
+            copyDocumentContextParameters(sourceContext.getApplicationSpecifiedDocumentContextParameter(),
+                    target.getApplicationSpecifiedDocumentContextParameter());
+            copyDocumentContextParameters(sourceContext.getGuidelineSpecifiedDocumentContextParameter(),
+                    target.getGuidelineSpecifiedDocumentContextParameter());
+            copyDocumentContextParameters(sourceContext.getSubsetSpecifiedDocumentContextParameter(),
+                    target.getSubsetSpecifiedDocumentContextParameter());
+            if (sourceContext.getMessageStandardSpecifiedDocumentContextParameter() != null) {
+                target.setMessageStandardSpecifiedDocumentContextParameter(
+                        copyDocumentContextParameter(sourceContext.getMessageStandardSpecifiedDocumentContextParameter()));
+            }
+            copyDocumentContextParameters(sourceContext.getUserSpecifiedDocumentContextParameter(),
+                    target.getUserSpecifiedDocumentContextParameter());
+            return target;
+        }
+
+        private ExchangedDocumentType mapDocument(String responseId, LocalDateTime issueDate,
+                                                  OrderResponseGenerationOptions options) {
+            ExchangedDocumentType document = new ExchangedDocumentType();
+            document.setID(createId(responseId));
+
+            DocumentCodeType typeCode = new DocumentCodeType();
+            typeCode.setValue(options.getDocumentTypeCode());
+            document.setTypeCode(typeCode);
+
+            DocumentStatusCodeType statusCode = new DocumentStatusCodeType();
+            statusCode.setValue(options.getAcknowledgementCode());
+            document.setStatusCode(statusCode);
+
+            DateTimeType dateTime = new DateTimeType();
+            DateTimeType.DateTimeString dateTimeString = new DateTimeType.DateTimeString();
+            dateTimeString.setFormat("102");
+            dateTimeString.setValue(ISSUE_DATE_FORMATTER.format(issueDate));
+            dateTime.setDateTimeString(dateTimeString);
+            document.setIssueDateTime(dateTime);
+
+            com.cii.messaging.unece.order.ExchangedDocumentType orderDocument = source.getExchangedDocument();
+            if (orderDocument != null) {
+                copyTexts(orderDocument.getName(), document.getName());
+                document.setPurpose(copyText(orderDocument.getPurpose()));
+                copyIds(orderDocument.getLanguageID(), document.getLanguageID());
+            }
+
+            return document;
+        }
+
+        private SupplyChainTradeTransactionType mapTransaction() {
+            SupplyChainTradeTransactionType transaction = new SupplyChainTradeTransactionType();
+            com.cii.messaging.unece.order.SupplyChainTradeTransactionType orderTransaction =
+                    source.getSupplyChainTradeTransaction();
+            if (orderTransaction == null) {
+                transaction.setApplicableHeaderTradeAgreement(mapHeaderTradeAgreement(null));
+                transaction.setApplicableHeaderTradeDelivery(mapHeaderTradeDelivery(null));
+                transaction.setApplicableHeaderTradeSettlement(mapHeaderTradeSettlement(null));
+                return transaction;
+            }
+
+            transaction.setApplicableHeaderTradeAgreement(mapHeaderTradeAgreement(
+                    orderTransaction.getApplicableHeaderTradeAgreement()));
+            transaction.setApplicableHeaderTradeDelivery(mapHeaderTradeDelivery(
+                    orderTransaction.getApplicableHeaderTradeDelivery()));
+            transaction.setApplicableHeaderTradeSettlement(mapHeaderTradeSettlement(
+                    orderTransaction.getApplicableHeaderTradeSettlement()));
+
+            List<com.cii.messaging.unece.order.SupplyChainTradeLineItemType> lines =
+                    orderTransaction.getIncludedSupplyChainTradeLineItem();
+            if (lines != null) {
+                for (com.cii.messaging.unece.order.SupplyChainTradeLineItemType line : lines) {
+                    transaction.getIncludedSupplyChainTradeLineItem().add(mapLineItem(line));
+                }
+            }
+            return transaction;
+        }
+
+        private HeaderTradeAgreementType mapHeaderTradeAgreement(
+                com.cii.messaging.unece.order.HeaderTradeAgreementType sourceAgreement) {
+            HeaderTradeAgreementType agreement = new HeaderTradeAgreementType();
+            if (sourceAgreement != null) {
+                agreement.setBuyerReference(copyText(sourceAgreement.getBuyerReference()));
+                agreement.setSellerTradeParty(copyTradeParty(sourceAgreement.getSellerTradeParty()));
+                agreement.setBuyerTradeParty(copyTradeParty(sourceAgreement.getBuyerTradeParty()));
+            }
+            if (orderId != null && !orderId.isBlank()) {
+                agreement.setSellerOrderReferencedDocument(createOrderReference(orderId));
+            }
+            return agreement;
+        }
+
+        private HeaderTradeDeliveryType mapHeaderTradeDelivery(
+                com.cii.messaging.unece.order.HeaderTradeDeliveryType sourceDelivery) {
+            HeaderTradeDeliveryType delivery = new HeaderTradeDeliveryType();
+            if (sourceDelivery != null) {
+                delivery.setShipToTradeParty(copyTradeParty(sourceDelivery.getShipToTradeParty()));
+                delivery.setUltimateShipToTradeParty(copyTradeParty(sourceDelivery.getUltimateShipToTradeParty()));
+                delivery.setShipFromTradeParty(copyTradeParty(sourceDelivery.getShipFromTradeParty()));
+            }
+            return delivery;
+        }
+
+        private HeaderTradeSettlementType mapHeaderTradeSettlement(
+                com.cii.messaging.unece.order.HeaderTradeSettlementType sourceSettlement) {
+            HeaderTradeSettlementType settlement = new HeaderTradeSettlementType();
+            if (sourceSettlement != null) {
+                settlement.setTaxCurrencyCode(copyCurrency(sourceSettlement.getTaxCurrencyCode()));
+                settlement.setOrderCurrencyCode(copyCurrency(sourceSettlement.getOrderCurrencyCode()));
+                settlement.setInvoiceCurrencyCode(copyCurrency(sourceSettlement.getInvoiceCurrencyCode()));
+                settlement.setPriceCurrencyCode(copyCurrency(sourceSettlement.getPriceCurrencyCode()));
+                copyAmounts(sourceSettlement.getDuePayableAmount(), settlement.getDuePayableAmount());
+                if (sourceSettlement.getSpecifiedTradeSettlementHeaderMonetarySummation() != null) {
+                    settlement.setSpecifiedTradeSettlementHeaderMonetarySummation(
+                            copyMonetarySummation(sourceSettlement.getSpecifiedTradeSettlementHeaderMonetarySummation()));
+                }
+            }
+            if (settlement.getSpecifiedTradeSettlementHeaderMonetarySummation() == null) {
+                settlement.setSpecifiedTradeSettlementHeaderMonetarySummation(new TradeSettlementHeaderMonetarySummationType());
+            }
+            return settlement;
+        }
+
+        private SupplyChainTradeLineItemType mapLineItem(
+                com.cii.messaging.unece.order.SupplyChainTradeLineItemType sourceLine) {
+            SupplyChainTradeLineItemType line = new SupplyChainTradeLineItemType();
+            line.setAssociatedDocumentLineDocument(copyLineDocument(sourceLine.getAssociatedDocumentLineDocument()));
+            line.setSpecifiedTradeProduct(copyTradeProduct(sourceLine.getSpecifiedTradeProduct()));
+            line.setSpecifiedLineTradeDelivery(copyLineDelivery(sourceLine.getSpecifiedLineTradeDelivery()));
+            return line;
+        }
+
+        private DocumentLineDocumentType copyLineDocument(
+                com.cii.messaging.unece.order.DocumentLineDocumentType sourceLineDoc) {
+            DocumentLineDocumentType target = new DocumentLineDocumentType();
+            if (sourceLineDoc != null) {
+                target.setLineID(copyId(sourceLineDoc.getLineID()));
+            }
+            return target;
+        }
+
+        private TradeProductType copyTradeProduct(com.cii.messaging.unece.order.TradeProductType sourceProduct) {
+            if (sourceProduct == null) {
+                return null;
+            }
+            TradeProductType product = new TradeProductType();
+            product.setID(copyId(sourceProduct.getID()));
+            copyIds(sourceProduct.getGlobalID(), product.getGlobalID());
+            product.setSellerAssignedID(copyId(sourceProduct.getSellerAssignedID()));
+            product.setBuyerAssignedID(copyId(sourceProduct.getBuyerAssignedID()));
+            copyTexts(sourceProduct.getName(), product.getName());
+            product.setTradeName(copyText(sourceProduct.getTradeName()));
+            return product;
+        }
+
+        private LineTradeDeliveryType copyLineDelivery(
+                com.cii.messaging.unece.order.LineTradeDeliveryType sourceDelivery) {
+            LineTradeDeliveryType delivery = new LineTradeDeliveryType();
+            if (sourceDelivery != null) {
+                delivery.setRequestedQuantity(copyQuantity(sourceDelivery.getRequestedQuantity()));
+                QuantityType agreed = copyQuantity(sourceDelivery.getAgreedQuantity());
+                if (agreed == null) {
+                    agreed = copyQuantity(sourceDelivery.getRequestedQuantity());
+                }
+                delivery.setAgreedQuantity(agreed);
+                delivery.setShipToTradeParty(copyTradeParty(sourceDelivery.getShipToTradeParty()));
+                delivery.setShipFromTradeParty(copyTradeParty(sourceDelivery.getShipFromTradeParty()));
+            }
+            return delivery;
+        }
+
+        private ReferencedDocumentType createOrderReference(String orderIdentifier) {
+            ReferencedDocumentType reference = new ReferencedDocumentType();
+            IDType issuer = createId(orderIdentifier);
+            reference.setIssuerAssignedID(issuer);
+            return reference;
+        }
+
+        private TradePartyType copyTradeParty(com.cii.messaging.unece.order.TradePartyType sourceParty) {
+            if (sourceParty == null) {
+                return null;
+            }
+            TradePartyType party = new TradePartyType();
+            copyIds(sourceParty.getID(), party.getID());
+            copyIds(sourceParty.getGlobalID(), party.getGlobalID());
+            party.setName(copyText(sourceParty.getName()));
+            party.setPostalTradeAddress(copyTradeAddress(sourceParty.getPostalTradeAddress()));
+            return party;
+        }
+
+        private TradeAddressType copyTradeAddress(com.cii.messaging.unece.order.TradeAddressType sourceAddress) {
+            if (sourceAddress == null) {
+                return null;
+            }
+            TradeAddressType address = new TradeAddressType();
+            address.setID(copyId(sourceAddress.getID()));
+            address.setPostcodeCode(copyCode(sourceAddress.getPostcodeCode()));
+            address.setLineOne(copyText(sourceAddress.getLineOne()));
+            address.setLineTwo(copyText(sourceAddress.getLineTwo()));
+            address.setLineThree(copyText(sourceAddress.getLineThree()));
+            address.setCityName(copyText(sourceAddress.getCityName()));
+            address.setCountryID(copyCountryId(sourceAddress.getCountryID()));
+            address.setCountrySubDivisionID(copyId(sourceAddress.getCountrySubDivisionID()));
+            copyTexts(sourceAddress.getCountryName(), address.getCountryName());
+            copyTexts(sourceAddress.getCountrySubDivisionName(), address.getCountrySubDivisionName());
+            return address;
+        }
+
+        private TradeSettlementHeaderMonetarySummationType copyMonetarySummation(
+                com.cii.messaging.unece.order.TradeSettlementHeaderMonetarySummationType sourceSummation) {
+            TradeSettlementHeaderMonetarySummationType target = new TradeSettlementHeaderMonetarySummationType();
+            if (sourceSummation == null) {
+                return target;
+            }
+            copyAmounts(sourceSummation.getLineTotalAmount(), target.getLineTotalAmount());
+            copyAmounts(sourceSummation.getChargeTotalAmount(), target.getChargeTotalAmount());
+            copyAmounts(sourceSummation.getAllowanceTotalAmount(), target.getAllowanceTotalAmount());
+            copyAmounts(sourceSummation.getTaxBasisTotalAmount(), target.getTaxBasisTotalAmount());
+            copyAmounts(sourceSummation.getTaxTotalAmount(), target.getTaxTotalAmount());
+            copyAmounts(sourceSummation.getRoundingAmount(), target.getRoundingAmount());
+            copyAmounts(sourceSummation.getGrandTotalAmount(), target.getGrandTotalAmount());
+            copyAmounts(sourceSummation.getTotalPrepaidAmount(), target.getTotalPrepaidAmount());
+            copyAmounts(sourceSummation.getDuePayableAmount(), target.getDuePayableAmount());
+            copyAmounts(sourceSummation.getNetLineTotalAmount(), target.getNetLineTotalAmount());
+            copyAmounts(sourceSummation.getIncludingTaxesLineTotalAmount(), target.getIncludingTaxesLineTotalAmount());
+            return target;
+        }
+
+        private void copyAmounts(List<com.cii.messaging.unece.order.AmountType> sources, List<AmountType> targets) {
+            if (sources == null) {
+                return;
+            }
+            for (com.cii.messaging.unece.order.AmountType amount : sources) {
+                AmountType converted = copyAmount(amount);
+                if (converted != null) {
+                    targets.add(converted);
+                }
+            }
+        }
+
+        private void copyIds(List<com.cii.messaging.unece.order.IDType> sources, List<IDType> targets) {
+            if (sources == null) {
+                return;
+            }
+            for (com.cii.messaging.unece.order.IDType id : sources) {
+                IDType converted = copyId(id);
+                if (converted != null) {
+                    targets.add(converted);
+                }
+            }
+        }
+
+        private void copyTexts(List<com.cii.messaging.unece.order.TextType> sources, List<TextType> targets) {
+            if (sources == null) {
+                return;
+            }
+            for (com.cii.messaging.unece.order.TextType text : sources) {
+                TextType converted = copyText(text);
+                if (converted != null) {
+                    targets.add(converted);
+                }
+            }
+        }
+
+        private void copyDocumentContextParameters(
+                List<com.cii.messaging.unece.order.DocumentContextParameterType> sources,
+                List<DocumentContextParameterType> targets) {
+            if (sources == null) {
+                return;
+            }
+            for (com.cii.messaging.unece.order.DocumentContextParameterType parameter : sources) {
+                DocumentContextParameterType converted = copyDocumentContextParameter(parameter);
+                if (converted != null) {
+                    targets.add(converted);
+                }
+            }
+        }
+
+        private DocumentContextParameterType copyDocumentContextParameter(
+                com.cii.messaging.unece.order.DocumentContextParameterType sourceParameter) {
+            if (sourceParameter == null) {
+                return null;
+            }
+            DocumentContextParameterType parameter = new DocumentContextParameterType();
+            parameter.setID(copyId(sourceParameter.getID()));
+            parameter.setValue(copyText(sourceParameter.getValue()));
+            if (sourceParameter.getSpecifiedDocumentVersion() != null) {
+                parameter.setSpecifiedDocumentVersion(copyDocumentVersion(sourceParameter.getSpecifiedDocumentVersion()));
+            }
+            return parameter;
+        }
+
+        private com.cii.messaging.unece.orderresponse.DocumentVersionType copyDocumentVersion(
+                com.cii.messaging.unece.order.DocumentVersionType sourceVersion) {
+            if (sourceVersion == null) {
+                return null;
+            }
+            com.cii.messaging.unece.orderresponse.DocumentVersionType version =
+                    new com.cii.messaging.unece.orderresponse.DocumentVersionType();
+            version.setID(copyId(sourceVersion.getID()));
+            version.setName(copyText(sourceVersion.getName()));
+            version.setIssueDateTime(copyDateTime(sourceVersion.getIssueDateTime()));
+            return version;
+        }
+
+        private IDType copyId(com.cii.messaging.unece.order.IDType sourceId) {
+            if (sourceId == null) {
+                return null;
+            }
+            IDType id = new IDType();
+            id.setValue(sourceId.getValue());
+            id.setSchemeID(sourceId.getSchemeID());
+            id.setSchemeName(sourceId.getSchemeName());
+            id.setSchemeAgencyID(sourceId.getSchemeAgencyID());
+            id.setSchemeAgencyName(sourceId.getSchemeAgencyName());
+            id.setSchemeVersionID(sourceId.getSchemeVersionID());
+            id.setSchemeDataURI(sourceId.getSchemeDataURI());
+            id.setSchemeURI(sourceId.getSchemeURI());
+            return id;
+        }
+
+        private IDType createId(String value) {
+            if (value == null) {
+                return null;
+            }
+            IDType id = new IDType();
+            id.setValue(value);
+            return id;
+        }
+
+        private TextType copyText(com.cii.messaging.unece.order.TextType sourceText) {
+            if (sourceText == null) {
+                return null;
+            }
+            TextType text = new TextType();
+            text.setValue(sourceText.getValue());
+            text.setLanguageID(sourceText.getLanguageID());
+            text.setLanguageLocaleID(sourceText.getLanguageLocaleID());
+            return text;
+        }
+
+        private CodeType copyCode(com.cii.messaging.unece.order.CodeType sourceCode) {
+            if (sourceCode == null) {
+                return null;
+            }
+            CodeType code = new CodeType();
+            code.setValue(sourceCode.getValue());
+            code.setListID(sourceCode.getListID());
+            code.setListAgencyID(sourceCode.getListAgencyID());
+            code.setListAgencyName(sourceCode.getListAgencyName());
+            code.setListVersionID(sourceCode.getListVersionID());
+            code.setName(sourceCode.getName());
+            code.setListName(sourceCode.getListName());
+            code.setLanguageID(sourceCode.getLanguageID());
+            code.setListURI(sourceCode.getListURI());
+            code.setListSchemeURI(sourceCode.getListSchemeURI());
+            return code;
+        }
+
+        private QuantityType copyQuantity(com.cii.messaging.unece.order.QuantityType sourceQuantity) {
+            if (sourceQuantity == null) {
+                return null;
+            }
+            QuantityType quantity = new QuantityType();
+            quantity.setValue(sourceQuantity.getValue());
+            quantity.setUnitCode(sourceQuantity.getUnitCode());
+            quantity.setUnitCodeListID(sourceQuantity.getUnitCodeListID());
+            quantity.setUnitCodeListAgencyID(sourceQuantity.getUnitCodeListAgencyID());
+            quantity.setUnitCodeListAgencyName(sourceQuantity.getUnitCodeListAgencyName());
+            return quantity;
+        }
+
+        private AmountType copyAmount(com.cii.messaging.unece.order.AmountType sourceAmount) {
+            if (sourceAmount == null) {
+                return null;
+            }
+            AmountType amount = new AmountType();
+            amount.setValue(sourceAmount.getValue());
+            amount.setCurrencyID(sourceAmount.getCurrencyID());
+            amount.setCurrencyCodeListVersionID(sourceAmount.getCurrencyCodeListVersionID());
+            return amount;
+        }
+
+        private CurrencyCodeType copyCurrency(com.cii.messaging.unece.order.CurrencyCodeType sourceCurrency) {
+            if (sourceCurrency == null) {
+                return null;
+            }
+            CurrencyCodeType currency = new CurrencyCodeType();
+            if (sourceCurrency.getValue() != null) {
+                currency.setValue(com.cii.messaging.unece.orderresponse.ISO3AlphaCurrencyCodeContentType
+                        .valueOf(sourceCurrency.getValue().name()));
+            }
+            currency.setListAgencyID(sourceCurrency.getListAgencyID());
+            return currency;
+        }
+
+        private com.cii.messaging.unece.orderresponse.CountryIDType copyCountryId(
+                com.cii.messaging.unece.order.CountryIDType sourceCountry) {
+            if (sourceCountry == null) {
+                return null;
+            }
+            com.cii.messaging.unece.orderresponse.CountryIDType country =
+                    new com.cii.messaging.unece.orderresponse.CountryIDType();
+            if (sourceCountry.getValue() != null) {
+                country.setValue(com.cii.messaging.unece.orderresponse.ISOTwoletterCountryCodeContentType
+                        .valueOf(sourceCountry.getValue().name()));
+            }
+            country.setSchemeAgencyID(sourceCountry.getSchemeAgencyID());
+            return country;
+        }
+
+        private DateTimeType copyDateTime(com.cii.messaging.unece.order.DateTimeType sourceDate) {
+            if (sourceDate == null) {
+                return null;
+            }
+            DateTimeType dateTime = new DateTimeType();
+            if (sourceDate.getDateTimeString() != null) {
+                DateTimeType.DateTimeString targetString = new DateTimeType.DateTimeString();
+                targetString.setFormat(sourceDate.getDateTimeString().getFormat());
+                targetString.setValue(sourceDate.getDateTimeString().getValue());
+                dateTime.setDateTimeString(targetString);
+            }
+            if (sourceDate.getDateTime() != null) {
+                dateTime.setDateTime(sourceDate.getDateTime());
+            }
+            return dateTime;
+        }
+
+        private com.cii.messaging.unece.orderresponse.IndicatorType copyIndicator(
+                com.cii.messaging.unece.order.IndicatorType sourceIndicator) {
+            if (sourceIndicator == null) {
+                return null;
+            }
+            com.cii.messaging.unece.orderresponse.IndicatorType indicator =
+                    new com.cii.messaging.unece.orderresponse.IndicatorType();
+            if (sourceIndicator.getIndicatorString() != null) {
+                com.cii.messaging.unece.orderresponse.IndicatorType.IndicatorString string =
+                        new com.cii.messaging.unece.orderresponse.IndicatorType.IndicatorString();
+                string.setFormat(sourceIndicator.getIndicatorString().getFormat());
+                string.setValue(sourceIndicator.getIndicatorString().getValue());
+                indicator.setIndicatorString(string);
+            }
+            indicator.setIndicator(sourceIndicator.isIndicator());
+            return indicator;
+        }
+    }
+}

--- a/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/generation/OrderResponseGeneratorTest.java
+++ b/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/generation/OrderResponseGeneratorTest.java
@@ -1,0 +1,192 @@
+package com.cii.messaging.writer.generation;
+
+import com.cii.messaging.model.order.Order;
+import com.cii.messaging.model.orderresponse.OrderResponse;
+import com.cii.messaging.unece.order.AmountType;
+import com.cii.messaging.unece.order.CurrencyCodeType;
+import com.cii.messaging.unece.order.DateTimeType;
+import com.cii.messaging.unece.order.DocumentLineDocumentType;
+import com.cii.messaging.unece.order.ExchangedDocumentContextType;
+import com.cii.messaging.unece.order.ExchangedDocumentType;
+import com.cii.messaging.unece.order.HeaderTradeAgreementType;
+import com.cii.messaging.unece.order.HeaderTradeDeliveryType;
+import com.cii.messaging.unece.order.HeaderTradeSettlementType;
+import com.cii.messaging.unece.order.IDType;
+import com.cii.messaging.unece.order.ISO3AlphaCurrencyCodeContentType;
+import com.cii.messaging.unece.order.LineTradeDeliveryType;
+import com.cii.messaging.unece.order.QuantityType;
+import com.cii.messaging.unece.order.SupplyChainTradeLineItemType;
+import com.cii.messaging.unece.order.SupplyChainTradeTransactionType;
+import com.cii.messaging.unece.order.TextType;
+import com.cii.messaging.unece.order.TradePartyType;
+import com.cii.messaging.unece.order.TradeProductType;
+import com.cii.messaging.unece.order.TradeSettlementHeaderMonetarySummationType;
+import com.cii.messaging.writer.CIIWriterException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OrderResponseGeneratorTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void transformeCommandeEnOrderResponse() {
+        Order order = buildOrder();
+
+        OrderResponseGenerationOptions options = OrderResponseGenerationOptions.builder()
+                .withResponseIdPrefix("RSP-")
+                .withIssueDateTime(LocalDateTime.of(2024, 3, 5, 12, 0))
+                .withAcknowledgementCode("AP")
+                .build();
+
+        OrderResponse response = OrderResponseGenerator.genererDepuisOrder(order, options);
+
+        assertEquals("RSP-DOC-001", response.getExchangedDocument().getID().getValue());
+        assertEquals("AP", response.getExchangedDocument().getStatusCode().getValue());
+        assertEquals("20240305120000",
+                response.getExchangedDocument().getIssueDateTime().getDateTimeString().getValue());
+        assertEquals(1, response.getSupplyChainTradeTransaction().getIncludedSupplyChainTradeLineItem().size());
+        assertEquals(new BigDecimal("5"), response.getSupplyChainTradeTransaction().getIncludedSupplyChainTradeLineItem().get(0)
+                .getSpecifiedLineTradeDelivery().getAgreedQuantity().getValue());
+        assertEquals("DOC-001", response.getSupplyChainTradeTransaction().getApplicableHeaderTradeAgreement()
+                .getSellerOrderReferencedDocument().getIssuerAssignedID().getValue());
+        assertEquals(1, response.getSupplyChainTradeTransaction().getApplicableHeaderTradeSettlement()
+                .getSpecifiedTradeSettlementHeaderMonetarySummation().getGrandTotalAmount().size());
+    }
+
+    @Test
+    void ecritOrderResponseSurDisque() throws IOException, CIIWriterException {
+        Order order = buildOrder();
+        Path output = tempDir.resolve("ordersp.xml");
+
+        String message = OrderResponseGenerator.genererOrderResponse(order, output.toString(),
+                OrderResponseGenerationOptions.builder()
+                        .withIssueDateTime(LocalDateTime.of(2024, 3, 5, 12, 0))
+                        .build());
+
+        assertTrue(Files.exists(output));
+        assertTrue(message.contains(output.toAbsolutePath().toString()));
+        String content = Files.readString(output, StandardCharsets.UTF_8);
+        assertTrue(content.contains("CrossIndustryOrderResponse"));
+    }
+
+    private static Order buildOrder() {
+        Order order = new Order();
+
+        ExchangedDocumentContextType context = new ExchangedDocumentContextType();
+        context.setSpecifiedTransactionID(id("TRANS-001"));
+        order.setExchangedDocumentContext(context);
+
+        ExchangedDocumentType document = new ExchangedDocumentType();
+        document.setID(id("DOC-001"));
+        DateTimeType dateTime = new DateTimeType();
+        DateTimeType.DateTimeString dateTimeString = new DateTimeType.DateTimeString();
+        dateTimeString.setFormat("102");
+        dateTimeString.setValue("20240201093000");
+        dateTime.setDateTimeString(dateTimeString);
+        document.setIssueDateTime(dateTime);
+        document.getName().add(text("Commande Test"));
+        order.setExchangedDocument(document);
+
+        SupplyChainTradeTransactionType transaction = new SupplyChainTradeTransactionType();
+        transaction.setApplicableHeaderTradeAgreement(buildAgreement());
+        transaction.setApplicableHeaderTradeDelivery(buildDelivery());
+        transaction.setApplicableHeaderTradeSettlement(buildSettlement());
+        transaction.getIncludedSupplyChainTradeLineItem().add(buildLine());
+        order.setSupplyChainTradeTransaction(transaction);
+
+        return order;
+    }
+
+    private static HeaderTradeAgreementType buildAgreement() {
+        HeaderTradeAgreementType agreement = new HeaderTradeAgreementType();
+        agreement.setBuyerReference(text("BUY-REF"));
+
+        TradePartyType seller = new TradePartyType();
+        seller.getID().add(id("SELLER-001"));
+        seller.setName(text("Fournisseur"));
+        agreement.setSellerTradeParty(seller);
+
+        TradePartyType buyer = new TradePartyType();
+        buyer.getID().add(id("BUYER-001"));
+        buyer.setName(text("Client"));
+        agreement.setBuyerTradeParty(buyer);
+
+        return agreement;
+    }
+
+    private static HeaderTradeDeliveryType buildDelivery() {
+        HeaderTradeDeliveryType delivery = new HeaderTradeDeliveryType();
+        TradePartyType shipTo = new TradePartyType();
+        shipTo.setName(text("Entrepôt Client"));
+        delivery.setShipToTradeParty(shipTo);
+        return delivery;
+    }
+
+    private static HeaderTradeSettlementType buildSettlement() {
+        HeaderTradeSettlementType settlement = new HeaderTradeSettlementType();
+        CurrencyCodeType currency = new CurrencyCodeType();
+        currency.setValue(ISO3AlphaCurrencyCodeContentType.EUR);
+        settlement.setOrderCurrencyCode(currency);
+
+        TradeSettlementHeaderMonetarySummationType summation = new TradeSettlementHeaderMonetarySummationType();
+        summation.getGrandTotalAmount().add(amount("250.00", "EUR"));
+        settlement.setSpecifiedTradeSettlementHeaderMonetarySummation(summation);
+        settlement.getDuePayableAmount().add(amount("250.00", "EUR"));
+        return settlement;
+    }
+
+    private static SupplyChainTradeLineItemType buildLine() {
+        SupplyChainTradeLineItemType line = new SupplyChainTradeLineItemType();
+
+        DocumentLineDocumentType lineDoc = new DocumentLineDocumentType();
+        lineDoc.setLineID(id("1"));
+        line.setAssociatedDocumentLineDocument(lineDoc);
+
+        TradeProductType product = new TradeProductType();
+        product.getName().add(text("Produit"));
+        line.setSpecifiedTradeProduct(product);
+
+        LineTradeDeliveryType delivery = new LineTradeDeliveryType();
+        delivery.setRequestedQuantity(quantity("5", "EA"));
+        line.setSpecifiedLineTradeDelivery(delivery);
+        return line;
+    }
+
+    private static IDType id(String value) {
+        IDType id = new IDType();
+        id.setValue(value);
+        return id;
+    }
+
+    private static TextType text(String value) {
+        TextType text = new TextType();
+        text.setValue(value);
+        return text;
+    }
+
+    private static AmountType amount(String value, String currency) {
+        AmountType amount = new AmountType();
+        amount.setValue(new BigDecimal(value));
+        amount.setCurrencyID(currency);
+        return amount;
+    }
+
+    private static QuantityType quantity(String value, String unit) {
+        QuantityType quantity = new QuantityType();
+        quantity.setValue(new BigDecimal(value));
+        quantity.setUnitCode(unit);
+        return quantity;
+    }
+}


### PR DESCRIPTION
## Summary
- add OrderResponseGenerator and immutable options builder to map ORDERS payloads into ORDER_RESPONSE structures
- expose a new `respond` CLI subcommand to create ORDER_RESPONSE files with configurable identifiers and acknowledgements
- document the respond command usage and wire the CLI module to the writer component

## Testing
- `mvn clean install`


------
https://chatgpt.com/codex/tasks/task_e_68d4e80e2d54832eb67aa798fbbab54d