### PR TITLE
feat: force build script to prefer java 21

### DIFF
--- a/cii-messaging-parent/scripts/build.sh
+++ b/cii-messaging-parent/scripts/build.sh
@@ -14,12 +14,77 @@ cd "${PROJECT_ROOT}"
 
 echo "🏗️ Construction du système de messagerie CII..."
 
-# Vérifier Java 21
-java_version=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}' | cut -d. -f1)
-if [ "${java_version}" -lt "21" ]; then
-    echo "❌ Java 21 ou supérieur est requis"
+ORIGINAL_PATH="${PATH}"
+
+check_java_version() {
+    local java_bin="$1"
+    if [ ! -x "${java_bin}" ]; then
+        return 1
+    fi
+    local version
+    version=$("${java_bin}" -version 2>&1 | awk -F '"' '/version/ {print $2}' | cut -d. -f1)
+    if [ -z "${version}" ]; then
+        return 1
+    fi
+    if [ "${version}" -lt 21 ]; then
+        return 1
+    fi
+    return 0
+}
+
+resolve_java_home() {
+    local java_path="$1"
+    local resolved
+    resolved=$(readlink -f "${java_path}" 2>/dev/null || echo "${java_path}")
+    cd "$(dirname "${resolved}")/.." && pwd
+}
+
+select_java21() {
+    local current_java
+    current_java=$(command -v java || true)
+    if [ -n "${current_java}" ]; then
+        local current_home
+        current_home=$(resolve_java_home "${current_java}")
+        if check_java_version "${current_home}/bin/java"; then
+            export JAVA_HOME="${current_home}"
+            export PATH="${JAVA_HOME}/bin:${ORIGINAL_PATH}"
+            return 0
+        fi
+    fi
+
+    local candidates=()
+    if [ -n "${JAVA_HOME:-}" ]; then
+        candidates+=("${JAVA_HOME}")
+    fi
+    if [ -n "${JAVA21_HOME:-}" ]; then
+        candidates+=("${JAVA21_HOME}")
+    fi
+    if [ -d "/usr/lib/jvm/java-21-openjdk-amd64" ]; then
+        candidates+=("/usr/lib/jvm/java-21-openjdk-amd64")
+    fi
+    if command -v update-alternatives >/dev/null 2>&1; then
+        while IFS= read -r alt; do
+            candidates+=("$(cd "$(dirname "${alt}")/.." && pwd)")
+        done < <(update-alternatives --list java 2>/dev/null | grep 'java-21' || true)
+    fi
+
+    for candidate in "${candidates[@]}"; do
+        if [ -x "${candidate}/bin/java" ] && check_java_version "${candidate}/bin/java"; then
+            export JAVA_HOME="${candidate}"
+            export PATH="${JAVA_HOME}/bin:${ORIGINAL_PATH}"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+if ! select_java21; then
+    echo "❌ Java 21 ou supérieur est requis (aucun JDK 21 détecté)."
     exit 1
 fi
+
+echo "ℹ️ Utilisation de JAVA_HOME=${JAVA_HOME}"
 
 # Clean et build
 if ! mvn -f "${PROJECT_ROOT}/pom.xml" clean install -DskipTests; then


### PR DESCRIPTION
## Summary
- add helper functions in `scripts/build.sh` to resolve a Java 21 runtime and update `JAVA_HOME`/`PATH` dynamically
- fall back to common installation paths and update-alternatives entries to locate a JDK 21 before building
- log the selected runtime and abort early when no compatible JDK is found

## Testing
- ./scripts/build.sh

------
https://chatgpt.com/codex/tasks/task_e_68d500bbcc24832e8b036e03c3defb0b