### PR TITLE
Fix ORDER_RESPONSE status code validation

### DIFF
--- a/cii-messaging-parent/README.md
+++ b/cii-messaging-parent/README.md
@@ -134,7 +134,7 @@ Génère automatiquement un ORDER_RESPONSE (ORDERSP) à partir d’un ORDER exis
 | `-o, --output <FILE>` | Fichier ORDER_RESPONSE à produire | `<INPUT>-ordersp.xml` dans le même dossier |
 | `--response-id <ID>` | Identifiant explicite du document ORDER_RESPONSE | Préfixe + ID de l’ORDER |
 | `--response-id-prefix <PREFIX>` | Préfixe utilisé pour générer l’ID si aucun n’est fourni | `ORDRSP-` |
-| `--ack-code <CODE>` | Code d’accusé de réception (AP=Accepté, RE=Rejeté, …) | `AP` |
+| `--ack-code <CODE>` | Code d’accusé de réception UNECE (1–51, ex. `29`=Accepté, `42`=Rejeté) | `29` |
 | `--issue-date <yyyyMMddHHmmss>` | Date d’émission forcée | Date courante |
 
 La commande lit le message ORDER, reconstruit les entêtes (parties, montants, lignes) et produit un ORDER_RESPONSE

--- a/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/RespondCommand.java
+++ b/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/RespondCommand.java
@@ -4,6 +4,7 @@ import com.cii.messaging.model.order.Order;
 import com.cii.messaging.reader.OrderReader;
 import com.cii.messaging.reader.CIIReaderException;
 import com.cii.messaging.writer.CIIWriterException;
+import com.cii.messaging.writer.generation.DocumentStatusCodes;
 import com.cii.messaging.writer.generation.OrderResponseGenerationOptions;
 import com.cii.messaging.writer.generation.OrderResponseGenerator;
 import org.slf4j.Logger;
@@ -38,8 +39,10 @@ public class RespondCommand extends AbstractCommand implements Callable<Integer>
     @Option(names = "--response-id", description = "Identifiant explicite du ORDER_RESPONSE généré")
     private String responseId;
 
-    @Option(names = "--ack-code", description = "Code d'accusé de réception (ex: AP, RE)", defaultValue = "AP")
-    private String acknowledgementCode = "AP";
+    @Option(names = "--ack-code",
+            description = "Code d'accusé de réception UNECE (ex: 29=Accepté, 42=Rejeté)",
+            defaultValue = DocumentStatusCodes.DEFAULT_ACKNOWLEDGEMENT_CODE)
+    private String acknowledgementCode = DocumentStatusCodes.DEFAULT_ACKNOWLEDGEMENT_CODE;
 
     @Option(names = "--issue-date", description = "Date d'émission au format yyyyMMddHHmmss")
     private String issueDate;
@@ -75,6 +78,10 @@ public class RespondCommand extends AbstractCommand implements Callable<Integer>
             return 1;
         } catch (DateTimeParseException e) {
             logger.error("Format de date invalide pour --issue-date (attendu yyyyMMddHHmmss) : {}", e.getParsedString());
+            return 1;
+        } catch (IllegalArgumentException e) {
+            logger.error("Paramétrage invalide : {}", e.getMessage());
+            logger.debug("Erreur complète", e);
             return 1;
         } catch (IOException | CIIWriterException e) {
             logger.error("Erreur lors de la génération du ORDER_RESPONSE : {}", e.getMessage());

--- a/cii-messaging-parent/cii-cli/src/test/java/com/cii/messaging/cli/RespondCommandTest.java
+++ b/cii-messaging-parent/cii-cli/src/test/java/com/cii/messaging/cli/RespondCommandTest.java
@@ -27,7 +27,7 @@ class RespondCommandTest {
         int exitCode = new CommandLine(new RespondCommand()).execute(
                 input.toString(),
                 "--output", output.toString(),
-                "--ack-code", "RE",
+                "--ack-code", "42",
                 "--issue-date", "20240305120000"
         );
 
@@ -36,7 +36,7 @@ class RespondCommandTest {
 
         OrderResponse response = lireOrderResponse(output);
         assertThat(response.getExchangedDocument().getID().getValue()).isEqualTo("ORDRSP-ORD-2024-001");
-        assertThat(response.getExchangedDocument().getStatusCode().getValue()).isEqualTo("RE");
+        assertThat(response.getExchangedDocument().getStatusCode().getValue()).isEqualTo("42");
         assertThat(response.getSupplyChainTradeTransaction().getIncludedSupplyChainTradeLineItem()).hasSize(2);
         assertThat(response.getSupplyChainTradeTransaction().getIncludedSupplyChainTradeLineItem().get(0)
                 .getSpecifiedLineTradeDelivery().getAgreedQuantity().getValue()).isEqualByComparingTo("100");

--- a/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/DocumentStatusCodes.java
+++ b/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/DocumentStatusCodes.java
@@ -1,0 +1,53 @@
+package com.cii.messaging.writer.generation;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Liste utilitaire des codes UNECE valides pour {@code DocumentStatusCode} dans un ORDER_RESPONSE.
+ *
+ * <p>Les codes correspondent à la liste officielle « Document Status Code » disponible sur le site de l'UNECE
+ * (publication Supply Chain Management &gt; CIOP/CIOR). Cette classe permet de vérifier rapidement qu'un code fourni
+ * par l'utilisateur appartient à l'intervalle autorisé (1 à 51 pour D23A/D24A) tout en centralisant la valeur par
+ * défaut utilisée par le générateur.</p>
+ */
+public final class DocumentStatusCodes {
+
+    /** Code indiquant une acceptation de la commande sans modification (valeur par défaut). */
+    public static final String DEFAULT_ACKNOWLEDGEMENT_CODE = "29";
+
+    private static final Set<String> VALID_CODES;
+
+    static {
+        Set<String> codes = IntStream.rangeClosed(1, 51)
+                .mapToObj(String::valueOf)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        VALID_CODES = Collections.unmodifiableSet(codes);
+    }
+
+    private DocumentStatusCodes() {
+        // utilitaire
+    }
+
+    /**
+     * Indique si le code fourni figure dans la liste officielle UNECE.
+     *
+     * @param code valeur à tester (peut être {@code null})
+     * @return {@code true} si le code est reconnu, sinon {@code false}
+     */
+    public static boolean isValid(String code) {
+        return code != null && VALID_CODES.contains(code);
+    }
+
+    /**
+     * Retourne la liste immuable des codes acceptés afin d'afficher un message d'erreur explicite.
+     *
+     * @return ensemble trié des codes valides
+     */
+    public static Set<String> validCodes() {
+        return VALID_CODES;
+    }
+}

--- a/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/OrderResponseGenerationOptions.java
+++ b/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/OrderResponseGenerationOptions.java
@@ -103,7 +103,7 @@ public final class OrderResponseGenerationOptions {
     public static final class Builder {
         private String responseId;
         private String responseIdPrefix = "ORDRSP-";
-        private String acknowledgementCode = "AP";
+        private String acknowledgementCode = DocumentStatusCodes.DEFAULT_ACKNOWLEDGEMENT_CODE;
         private String documentTypeCode = "231";
         private LocalDateTime issueDateTime;
         private Clock clock = Clock.systemUTC();
@@ -140,7 +140,17 @@ public final class OrderResponseGenerationOptions {
          * @return builder pour chaînage
          */
         public Builder withAcknowledgementCode(String acknowledgementCode) {
-            this.acknowledgementCode = Objects.requireNonNull(acknowledgementCode, "acknowledgementCode");
+            String trimmed = Objects.requireNonNull(acknowledgementCode, "acknowledgementCode").trim();
+            if (trimmed.isEmpty()) {
+                throw new IllegalArgumentException("Le code d'accusé de réception ne peut pas être vide");
+            }
+            if (!DocumentStatusCodes.isValid(trimmed)) {
+                throw new IllegalArgumentException(String.format(
+                        "Code d'accusé de réception '%s' invalide. Référez-vous à la liste UNECE : %s",
+                        trimmed,
+                        DocumentStatusCodes.validCodes()));
+            }
+            this.acknowledgementCode = trimmed;
             return this;
         }
 

--- a/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/generation/OrderResponseGenerationOptionsTest.java
+++ b/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/generation/OrderResponseGenerationOptionsTest.java
@@ -1,0 +1,27 @@
+package com.cii.messaging.writer.generation;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class OrderResponseGenerationOptionsTest {
+
+    @Test
+    void utiliseCodeParDefautConforme() {
+        OrderResponseGenerationOptions options = OrderResponseGenerationOptions.defaults();
+
+        assertEquals(DocumentStatusCodes.DEFAULT_ACKNOWLEDGEMENT_CODE, options.getAcknowledgementCode());
+    }
+
+    @Test
+    void rejetteCodeNonReferenceParUnece() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+                OrderResponseGenerationOptions.builder()
+                        .withAcknowledgementCode("AP")
+                        .build());
+
+        assertEquals("Code d'accusé de réception 'AP' invalide. Référez-vous à la liste UNECE : "
+                + DocumentStatusCodes.validCodes(), exception.getMessage());
+    }
+}

--- a/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/generation/OrderResponseGeneratorTest.java
+++ b/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/generation/OrderResponseGeneratorTest.java
@@ -47,13 +47,14 @@ class OrderResponseGeneratorTest {
         OrderResponseGenerationOptions options = OrderResponseGenerationOptions.builder()
                 .withResponseIdPrefix("RSP-")
                 .withIssueDateTime(LocalDateTime.of(2024, 3, 5, 12, 0))
-                .withAcknowledgementCode("AP")
+                .withAcknowledgementCode(DocumentStatusCodes.DEFAULT_ACKNOWLEDGEMENT_CODE)
                 .build();
 
         OrderResponse response = OrderResponseGenerator.genererDepuisOrder(order, options);
 
         assertEquals("RSP-DOC-001", response.getExchangedDocument().getID().getValue());
-        assertEquals("AP", response.getExchangedDocument().getStatusCode().getValue());
+        assertEquals(DocumentStatusCodes.DEFAULT_ACKNOWLEDGEMENT_CODE,
+                response.getExchangedDocument().getStatusCode().getValue());
         assertEquals("20240305120000",
                 response.getExchangedDocument().getIssueDateTime().getDateTimeString().getValue());
         assertEquals(1, response.getSupplyChainTradeTransaction().getIncludedSupplyChainTradeLineItem().size());


### PR DESCRIPTION
## Summary
- centralize UNECE document status codes and update the ORDER_RESPONSE generator default to the official value `29`
- validate acknowledgement codes provided through the generator builder and CLI, surfacing helpful errors for invalid values
- refresh CLI/docs/tests to use numeric UNECE codes and cover the new validation logic

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68d51a279bf0832e94f9411b2667124c