### PR TITLE
Aligner la génération ORDER_RESPONSE sur la nomenclature D23B

### DIFF
--- a/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/DocumentStatusCodes.java
+++ b/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/DocumentStatusCodes.java
@@ -1,5 +1,17 @@
 package com.cii.messaging.writer.generation;
 
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -9,23 +21,23 @@ import java.util.stream.IntStream;
 /**
  * Liste utilitaire des codes UNECE valides pour {@code DocumentStatusCode} dans un ORDER_RESPONSE.
  *
- * <p>Les codes correspondent à la liste officielle « Document Status Code » disponible sur le site de l'UNECE
- * (publication Supply Chain Management &gt; CIOP/CIOR). Cette classe permet de vérifier rapidement qu'un code fourni
- * par l'utilisateur appartient à l'intervalle autorisé (1 à 51 pour D23A/D24A) tout en centralisant la valeur par
- * défaut utilisée par le générateur.</p>
+ * <p>Les codes correspondent à la liste officielle « Document Status Code » disponible dans les schémas
+ * CrossIndustryOrderResponse D23B. La liste est chargée dynamiquement depuis le fichier XSD embarqué afin de garantir
+ * une conformité stricte au standard UNECE, y compris lorsque la taxonomie évolue.</p>
  */
 public final class DocumentStatusCodes {
 
     /** Code indiquant une acceptation de la commande sans modification (valeur par défaut). */
     public static final String DEFAULT_ACKNOWLEDGEMENT_CODE = "29";
 
+    private static final String DOCUMENT_STATUS_RESOURCE =
+            "/xsd/D23B/CrossIndustryOrderResponse_100pD23B_urn_un_unece_uncefact_codelist_standard_"
+                    + "UNECE_DocumentStatusCode_D23A.xsd";
     private static final Set<String> VALID_CODES;
+    private static final Set<String> FALLBACK_CODES = buildFallbackCodes();
 
     static {
-        Set<String> codes = IntStream.rangeClosed(1, 51)
-                .mapToObj(String::valueOf)
-                .collect(Collectors.toCollection(LinkedHashSet::new));
-        VALID_CODES = Collections.unmodifiableSet(codes);
+        VALID_CODES = loadCodes();
     }
 
     private DocumentStatusCodes() {
@@ -49,5 +61,59 @@ public final class DocumentStatusCodes {
      */
     public static Set<String> validCodes() {
         return VALID_CODES;
+    }
+
+    private static Set<String> loadCodes() {
+        try (InputStream stream = DocumentStatusCodes.class.getResourceAsStream(DOCUMENT_STATUS_RESOURCE)) {
+            if (stream == null) {
+                return FALLBACK_CODES;
+            }
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setNamespaceAware(true);
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            disableExternalEntities(factory);
+
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            Document document = builder.parse(stream);
+            NodeList nodes = document.getElementsByTagNameNS(XMLConstants.W3C_XML_SCHEMA_NS_URI, "enumeration");
+            if (nodes == null || nodes.getLength() == 0) {
+                return FALLBACK_CODES;
+            }
+
+            Set<String> codes = new LinkedHashSet<>();
+            for (int i = 0; i < nodes.getLength(); i++) {
+                String value = nodes.item(i).getAttributes().getNamedItem("value").getNodeValue();
+                if (value != null && !value.isBlank()) {
+                    codes.add(value.trim());
+                }
+            }
+            return Collections.unmodifiableSet(codes);
+        } catch (ParserConfigurationException e) {
+            throw new IllegalStateException("Impossible d'initialiser le parseur XML pour les codes d'accusé UNECE", e);
+        } catch (SAXException e) {
+            throw new IllegalStateException("Fichier XSD UNECE invalide pour les codes d'accusé", e);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Impossible de lire la liste des codes UNECE", e);
+        }
+    }
+
+    private static void disableExternalEntities(DocumentBuilderFactory factory) {
+        try {
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        } catch (IllegalArgumentException ignored) {
+            // propriété non supportée selon l'implémentation, on ignore.
+        }
+        try {
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        } catch (IllegalArgumentException ignored) {
+            // idem.
+        }
+    }
+
+    private static Set<String> buildFallbackCodes() {
+        Set<String> codes = IntStream.rangeClosed(1, 51)
+                .mapToObj(String::valueOf)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        return Collections.unmodifiableSet(codes);
     }
 }

--- a/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/OrderResponseGenerator.java
+++ b/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/OrderResponseGenerator.java
@@ -186,10 +186,12 @@ public final class OrderResponseGenerator {
 
             DocumentCodeType typeCode = new DocumentCodeType();
             typeCode.setValue(options.getDocumentTypeCode());
+            typeCode.setListAgencyID("6");
             document.setTypeCode(typeCode);
 
             DocumentStatusCodeType statusCode = new DocumentStatusCodeType();
             statusCode.setValue(options.getAcknowledgementCode());
+            statusCode.setListAgencyID("6");
             document.setStatusCode(statusCode);
 
             DateTimeType dateTime = new DateTimeType();

--- a/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/generation/DocumentStatusCodesTest.java
+++ b/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/generation/DocumentStatusCodesTest.java
@@ -1,0 +1,23 @@
+package com.cii.messaging.writer.generation;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DocumentStatusCodesTest {
+
+    @Test
+    void chargeCodesDepuisLeSchemaD23B() {
+        Set<String> codes = DocumentStatusCodes.validCodes();
+
+        assertFalse(codes.isEmpty(), "La liste des codes UNECE ne doit pas être vide");
+        assertTrue(codes.contains(DocumentStatusCodes.DEFAULT_ACKNOWLEDGEMENT_CODE),
+                "Le code par défaut doit être présent dans la liste");
+        assertTrue(codes.contains("1"), "Le premier code de la nomenclature doit être disponible");
+        assertTrue(codes.contains("51"), "Le dernier code de la nomenclature D23B doit être disponible");
+        assertFalse(codes.contains("0"), "Les valeurs hors nomenclature doivent être rejetées");
+    }
+}

--- a/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/generation/OrderResponseGeneratorTest.java
+++ b/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/generation/OrderResponseGeneratorTest.java
@@ -55,6 +55,8 @@ class OrderResponseGeneratorTest {
         assertEquals("RSP-DOC-001", response.getExchangedDocument().getID().getValue());
         assertEquals(DocumentStatusCodes.DEFAULT_ACKNOWLEDGEMENT_CODE,
                 response.getExchangedDocument().getStatusCode().getValue());
+        assertEquals("6", response.getExchangedDocument().getStatusCode().getListAgencyID());
+        assertEquals("6", response.getExchangedDocument().getTypeCode().getListAgencyID());
         assertEquals("20240305120000",
                 response.getExchangedDocument().getIssueDateTime().getDateTimeString().getValue());
         assertEquals(1, response.getSupplyChainTradeTransaction().getIncludedSupplyChainTradeLineItem().size());


### PR DESCRIPTION
## Summary
- Charger dynamiquement les codes d'accusé UNECE depuis le XSD D23B pour sécuriser la validation ORDER_RESPONSE
- Forcer les attributs listAgencyID sur les codes de type et de statut afin de garantir la conformité D23B
- Couvrir la résolution des codes par des tests unitaires dédiés et enrichir ceux du générateur ORDER_RESPONSE

## Testing
- mvn -pl cii-model,cii-samples -am install -DskipTests
- mvn -pl cii-writer test

------
https://chatgpt.com/codex/tasks/task_e_68d52afaea14832eadf407ecc3ac9148