### PR TITLE
Ensure ORDER_RESPONSE generator copies line pricing details

### DIFF
--- a/cii-messaging-parent/cii-writer/pom.xml
+++ b/cii-messaging-parent/cii-writer/pom.xml
@@ -51,6 +51,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.cii.messaging</groupId>
+            <artifactId>cii-reader</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
## Summary
- preserve line trade agreements and settlements when mapping ORDER to ORDER_RESPONSE by reusing reflective copy utilities
- add coverage to assert that prices and line totals from the Amazon sample persist in generated ORDER_RESPONSE output
- include cii-reader as a test dependency so writer tests can deserialize sample ORDER fixtures

## Testing
- mvn -pl cii-writer -am test
- java -jar cii-cli/target/cii-cli-1.0.0-SNAPSHOT-jar-with-dependencies.jar respond --ack-code 1 --response-id-prefix ORDRSP- --output target/order-response.xml cii-samples/src/main/resources/samples/AMAZON_OUT.xml


------
https://chatgpt.com/codex/tasks/task_e_68d637d37e0c832e9f4dd2cd697d1836