### PR TITLE
Fix order response sample loading in tests

### DIFF
--- a/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/generation/OrderResponseGeneratorTest.java
+++ b/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/generation/OrderResponseGeneratorTest.java
@@ -32,8 +32,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.math.BigDecimal;
-import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -237,9 +237,12 @@ class OrderResponseGeneratorTest {
         return quantity;
     }
 
-    private Order lireEchantillonOrder(String resource)
-            throws IOException, URISyntaxException, CIIReaderException {
-        Path source = Path.of(getClass().getResource(resource).toURI());
-        return new OrderReader().read(source.toFile());
+    private Order lireEchantillonOrder(String resource) throws IOException, CIIReaderException {
+        try (InputStream inputStream = getClass().getResourceAsStream(resource)) {
+            if (inputStream == null) {
+                throw new IOException("Ressource introuvable : " + resource);
+            }
+            return new OrderReader().read(inputStream);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- read the Amazon sample order through a classpath stream so tests work when resources reside in dependency JARs

## Testing
- mvn -pl cii-writer -am test

------
https://chatgpt.com/codex/tasks/task_e_68d65d2fd6d0832e84c71a4bb82aaac9