### PR TITLE
feat: ensure standard CII namespace prefixes in writer output

### DIFF
--- a/cii-messaging-parent/README.md
+++ b/cii-messaging-parent/README.md
@@ -140,6 +140,8 @@ Génère automatiquement un ORDER_RESPONSE (ORDERSP) à partir d’un ORDER exis
 La commande lit le message ORDER, reconstruit les entêtes (parties, montants, lignes) et produit un ORDER_RESPONSE
 cohérent avec les quantités demandées.
 
+Generated XML now declares the canonical CII prefixes (`rsm`, `ram`, `udt`, `qdt`) so that CLI outputs match UNECE interoperability requirements.
+
 ```bash
 # Générer une réponse acceptée pour order-sample.xml et l’écrire dans target/order-response.xml
 java -jar cii-cli/target/cii-cli-1.0.0-SNAPSHOT-jar-with-dependencies.jar \

--- a/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/CIINamespacePrefixMapper.java
+++ b/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/CIINamespacePrefixMapper.java
@@ -1,0 +1,26 @@
+package com.cii.messaging.writer;
+
+import org.glassfish.jaxb.runtime.marshaller.NamespacePrefixMapper;
+
+import java.util.Map;
+
+/**
+ * Provides the standard CII namespace prefixes expected by trading partners.
+ */
+public class CIINamespacePrefixMapper extends NamespacePrefixMapper {
+
+    private static final Map<String, String> PREFIXES = Map.ofEntries(
+            Map.entry("urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100", "ram"),
+            Map.entry("urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100", "udt"),
+            Map.entry("urn:un:unece:uncefact:data:standard:QualifiedDataType:100", "qdt"),
+            Map.entry("urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100", "rsm"),
+            Map.entry("urn:un:unece:uncefact:data:standard:CrossIndustryOrder:100", "rsm"),
+            Map.entry("urn:un:unece:uncefact:data:standard:CrossIndustryOrderResponse:100", "rsm"),
+            Map.entry("urn:un:unece:uncefact:data:standard:CrossIndustryDespatchAdvice:100", "rsm")
+    );
+
+    @Override
+    public String getPreferredPrefix(String namespaceUri, String suggestion, boolean requirePrefix) {
+        return PREFIXES.getOrDefault(namespaceUri, suggestion);
+    }
+}

--- a/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/JaxbWriter.java
+++ b/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/JaxbWriter.java
@@ -3,6 +3,10 @@ package com.cii.messaging.writer;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.PropertyException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.OutputStream;
@@ -12,6 +16,9 @@ import java.io.StringWriter;
  * Implémentation générique de {@link CIIWriter} reposant sur JAXB.
  */
 public class JaxbWriter<T> implements CIIWriter<T> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(JaxbWriter.class);
+    private static final String NAMESPACE_PREFIX_MAPPER_PROPERTY = "com.sun.xml.bind.namespacePrefixMapper";
+
     private final JAXBContext context;
     private boolean formatOutput = true;
     private String encoding = "UTF-8";
@@ -36,9 +43,7 @@ public class JaxbWriter<T> implements CIIWriter<T> {
     @Override
     public void write(T message, OutputStream outputStream) throws CIIWriterException {
         try {
-            Marshaller marshaller = context.createMarshaller();
-            marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, formatOutput);
-            marshaller.setProperty(Marshaller.JAXB_ENCODING, encoding);
+            Marshaller marshaller = createMarshaller();
             marshaller.marshal(message, outputStream);
         } catch (JAXBException e) {
             throw new CIIWriterException("Échec de l'écriture du message", e);
@@ -49,13 +54,36 @@ public class JaxbWriter<T> implements CIIWriter<T> {
     public String writeToString(T message) throws CIIWriterException {
         try {
             StringWriter sw = new StringWriter();
-            Marshaller marshaller = context.createMarshaller();
-            marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, formatOutput);
-            marshaller.setProperty(Marshaller.JAXB_ENCODING, encoding);
+            Marshaller marshaller = createMarshaller();
             marshaller.marshal(message, sw);
             return sw.toString();
         } catch (JAXBException e) {
             throw new CIIWriterException("Échec de l'écriture du message", e);
+        }
+    }
+
+    private Marshaller createMarshaller() throws JAXBException {
+        Marshaller marshaller = context.createMarshaller();
+        marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, formatOutput);
+        marshaller.setProperty(Marshaller.JAXB_ENCODING, encoding);
+        configureNamespacePrefixes(marshaller);
+        return marshaller;
+    }
+
+    private void configureNamespacePrefixes(Marshaller marshaller) {
+        CIINamespacePrefixMapper mapper = new CIINamespacePrefixMapper();
+        if (!setNamespaceMapperProperty(marshaller, NAMESPACE_PREFIX_MAPPER_PROPERTY, mapper)) {
+            setNamespaceMapperProperty(marshaller, "org.glassfish.jaxb.namespacePrefixMapper", mapper);
+        }
+    }
+
+    private boolean setNamespaceMapperProperty(Marshaller marshaller, String property, CIINamespacePrefixMapper mapper) {
+        try {
+            marshaller.setProperty(property, mapper);
+            return true;
+        } catch (PropertyException ex) {
+            LOGGER.debug("Namespace prefix mapper property '{}' not supported by current JAXB implementation", property, ex);
+            return false;
         }
     }
 

--- a/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/OrderResponseWriterTest.java
+++ b/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/OrderResponseWriterTest.java
@@ -1,0 +1,124 @@
+package com.cii.messaging.writer;
+
+import com.cii.messaging.model.orderresponse.OrderResponse;
+import com.cii.messaging.unece.orderresponse.AmountType;
+import com.cii.messaging.unece.orderresponse.CurrencyCodeType;
+import com.cii.messaging.unece.orderresponse.DateTimeType;
+import com.cii.messaging.unece.orderresponse.DocumentCodeType;
+import com.cii.messaging.unece.orderresponse.ExchangedDocumentContextType;
+import com.cii.messaging.unece.orderresponse.ExchangedDocumentType;
+import com.cii.messaging.unece.orderresponse.HeaderTradeAgreementType;
+import com.cii.messaging.unece.orderresponse.HeaderTradeDeliveryType;
+import com.cii.messaging.unece.orderresponse.HeaderTradeSettlementType;
+import com.cii.messaging.unece.orderresponse.IDType;
+import com.cii.messaging.unece.orderresponse.ISO3AlphaCurrencyCodeContentType;
+import com.cii.messaging.unece.orderresponse.SupplyChainTradeTransactionType;
+import com.cii.messaging.unece.orderresponse.TextType;
+import com.cii.messaging.unece.orderresponse.TradePartyType;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OrderResponseWriterTest {
+
+    @Test
+    void doitExposerLesPrefixesCiiStandards() throws Exception {
+        OrderResponse response = buildMinimalOrderResponse();
+
+        CIIWriter<OrderResponse> writer = new OrderResponseWriter();
+        String xml = writer.writeToString(response);
+
+        assertTrue(xml.contains("xmlns:rsm=\"urn:un:unece:uncefact:data:standard:CrossIndustryOrderResponse:100\""));
+        assertTrue(xml.contains("xmlns:ram=\"urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100\""));
+        assertTrue(xml.contains("xmlns:udt=\"urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100\""));
+        assertTrue(xml.contains("xmlns:qdt=\"urn:un:unece:uncefact:data:standard:QualifiedDataType:100\""));
+    }
+
+    private static OrderResponse buildMinimalOrderResponse() {
+        OrderResponse response = new OrderResponse();
+
+        ExchangedDocumentContextType context = new ExchangedDocumentContextType();
+        context.setSpecifiedTransactionID(id("TRANS-RESP-001"));
+        response.setExchangedDocumentContext(context);
+
+        ExchangedDocumentType document = new ExchangedDocumentType();
+        document.setID(id("RESP-2024-001"));
+        document.setTypeCode(documentCode("231"));
+        document.setIssueDateTime(dateTime("102", "20240101120000"));
+        response.setExchangedDocument(document);
+
+        SupplyChainTradeTransactionType transaction = new SupplyChainTradeTransactionType();
+        transaction.setApplicableHeaderTradeAgreement(buildAgreement());
+        transaction.setApplicableHeaderTradeDelivery(buildDelivery());
+        transaction.setApplicableHeaderTradeSettlement(buildSettlement());
+        response.setSupplyChainTradeTransaction(transaction);
+
+        return response;
+    }
+
+    private static HeaderTradeAgreementType buildAgreement() {
+        HeaderTradeAgreementType agreement = new HeaderTradeAgreementType();
+
+        TradePartyType seller = new TradePartyType();
+        seller.setName(text("Vendor"));
+        agreement.setSellerTradeParty(seller);
+
+        TradePartyType buyer = new TradePartyType();
+        buyer.setName(text("Customer"));
+        agreement.setBuyerTradeParty(buyer);
+
+        return agreement;
+    }
+
+    private static HeaderTradeDeliveryType buildDelivery() {
+        HeaderTradeDeliveryType delivery = new HeaderTradeDeliveryType();
+        TradePartyType shipTo = new TradePartyType();
+        shipTo.setName(text("Delivery Location"));
+        delivery.setShipToTradeParty(shipTo);
+        return delivery;
+    }
+
+    private static HeaderTradeSettlementType buildSettlement() {
+        HeaderTradeSettlementType settlement = new HeaderTradeSettlementType();
+
+        CurrencyCodeType currency = new CurrencyCodeType();
+        currency.setValue(ISO3AlphaCurrencyCodeContentType.EUR);
+        settlement.setOrderCurrencyCode(currency);
+
+        AmountType amount = new AmountType();
+        amount.setValue(new BigDecimal("120.00"));
+        amount.setCurrencyID("EUR");
+        settlement.getDuePayableAmount().add(amount);
+
+        return settlement;
+    }
+
+    private static IDType id(String value) {
+        IDType id = new IDType();
+        id.setValue(value);
+        return id;
+    }
+
+    private static TextType text(String value) {
+        TextType text = new TextType();
+        text.setValue(value);
+        return text;
+    }
+
+    private static DateTimeType dateTime(String format, String value) {
+        DateTimeType dateTime = new DateTimeType();
+        DateTimeType.DateTimeString dateTimeString = new DateTimeType.DateTimeString();
+        dateTimeString.setFormat(format);
+        dateTimeString.setValue(value);
+        dateTime.setDateTimeString(dateTimeString);
+        return dateTime;
+    }
+
+    private static DocumentCodeType documentCode(String value) {
+        DocumentCodeType code = new DocumentCodeType();
+        code.setValue(value);
+        return code;
+    }
+}


### PR DESCRIPTION
## Summary
- add a namespace prefix mapper that binds UNECE CII URNs to the expected rsm/ram/udt/qdt prefixes
- update the JAXB writer to register the mapper (with graceful fallback) and document the CLI behaviour change
- add an OrderResponse writer regression test that checks the generated XML prefixes

## Testing
- mvn -pl cii-writer -am test

------
https://chatgpt.com/codex/tasks/task_e_68d66b6b6714832eb292f74eb1189b30