### PR TITLE
Utiliser le code d'accusé dans PurposeCode

### DIFF
--- a/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/RespondCommand.java
+++ b/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/RespondCommand.java
@@ -4,7 +4,7 @@ import com.cii.messaging.model.order.Order;
 import com.cii.messaging.reader.OrderReader;
 import com.cii.messaging.reader.CIIReaderException;
 import com.cii.messaging.writer.CIIWriterException;
-import com.cii.messaging.writer.generation.DocumentStatusCodes;
+import com.cii.messaging.writer.generation.AcknowledgementCodes;
 import com.cii.messaging.writer.generation.OrderResponseGenerationOptions;
 import com.cii.messaging.writer.generation.OrderResponseGenerator;
 import org.slf4j.Logger;
@@ -41,8 +41,8 @@ public class RespondCommand extends AbstractCommand implements Callable<Integer>
 
     @Option(names = "--ack-code",
             description = "Code d'accusé de réception UNECE (ex: 29=Accepté, 42=Rejeté)",
-            defaultValue = DocumentStatusCodes.DEFAULT_ACKNOWLEDGEMENT_CODE)
-    private String acknowledgementCode = DocumentStatusCodes.DEFAULT_ACKNOWLEDGEMENT_CODE;
+            defaultValue = AcknowledgementCodes.DEFAULT_ACKNOWLEDGEMENT_CODE)
+    private String acknowledgementCode = AcknowledgementCodes.DEFAULT_ACKNOWLEDGEMENT_CODE;
 
     @Option(names = "--issue-date", description = "Date d'émission au format yyyyMMddHHmmss")
     private String issueDate;

--- a/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/AcknowledgementCodes.java
+++ b/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/AcknowledgementCodes.java
@@ -19,20 +19,20 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 /**
- * Liste utilitaire des codes UNECE valides pour {@code DocumentStatusCode} dans un ORDER_RESPONSE.
+ * Liste utilitaire des codes UNECE valides pour {@code MessageFunctionCodeType} dans un ORDER_RESPONSE.
  *
- * <p>Les codes correspondent à la liste officielle « Document Status Code » disponible dans les schémas
- * CrossIndustryOrderResponse D23B. La liste est chargée dynamiquement depuis le fichier XSD embarqué afin de garantir
- * une conformité stricte au standard UNECE, y compris lorsque la taxonomie évolue.</p>
+ * <p>Les codes correspondent à la liste officielle « Message Function Code » utilisée pour l'accusé de réception
+ * (PurposeCode) d'un document CrossIndustryOrderResponse D23B. La liste est chargée dynamiquement depuis le fichier
+ * XSD embarqué afin de garantir une conformité stricte au standard UNECE.</p>
  */
-public final class DocumentStatusCodes {
+public final class AcknowledgementCodes {
 
     /** Code indiquant une acceptation de la commande sans modification (valeur par défaut). */
     public static final String DEFAULT_ACKNOWLEDGEMENT_CODE = "1";
 
-    private static final String DOCUMENT_STATUS_RESOURCE =
+    private static final String MESSAGE_FUNCTION_RESOURCE =
             "/xsd/D23B/CrossIndustryOrderResponse_100pD23B_urn_un_unece_uncefact_codelist_standard_"
-                    + "UNECE_DocumentStatusCode_D23A.xsd";
+                    + "UNECE_MessageFunctionCode_D23A.xsd";
     private static final Set<String> VALID_CODES;
     private static final Set<String> FALLBACK_CODES = buildFallbackCodes();
 
@@ -40,7 +40,7 @@ public final class DocumentStatusCodes {
         VALID_CODES = loadCodes();
     }
 
-    private DocumentStatusCodes() {
+    private AcknowledgementCodes() {
         // utilitaire
     }
 
@@ -64,7 +64,7 @@ public final class DocumentStatusCodes {
     }
 
     private static Set<String> loadCodes() {
-        try (InputStream stream = DocumentStatusCodes.class.getResourceAsStream(DOCUMENT_STATUS_RESOURCE)) {
+        try (InputStream stream = AcknowledgementCodes.class.getResourceAsStream(MESSAGE_FUNCTION_RESOURCE)) {
             if (stream == null) {
                 return FALLBACK_CODES;
             }
@@ -111,7 +111,7 @@ public final class DocumentStatusCodes {
     }
 
     private static Set<String> buildFallbackCodes() {
-        Set<String> codes = IntStream.rangeClosed(1, 51)
+        Set<String> codes = IntStream.rangeClosed(1, 73)
                 .mapToObj(String::valueOf)
                 .collect(Collectors.toCollection(LinkedHashSet::new));
         return Collections.unmodifiableSet(codes);

--- a/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/OrderResponseGenerationOptions.java
+++ b/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/OrderResponseGenerationOptions.java
@@ -103,7 +103,7 @@ public final class OrderResponseGenerationOptions {
     public static final class Builder {
         private String responseId;
         private String responseIdPrefix = "ORDRSP-";
-        private String acknowledgementCode = DocumentStatusCodes.DEFAULT_ACKNOWLEDGEMENT_CODE;
+        private String acknowledgementCode = AcknowledgementCodes.DEFAULT_ACKNOWLEDGEMENT_CODE;
         private String documentTypeCode = "231";
         private LocalDateTime issueDateTime;
         private Clock clock = Clock.systemUTC();
@@ -144,11 +144,11 @@ public final class OrderResponseGenerationOptions {
             if (trimmed.isEmpty()) {
                 throw new IllegalArgumentException("Le code d'accusé de réception ne peut pas être vide");
             }
-            if (!DocumentStatusCodes.isValid(trimmed)) {
+            if (!AcknowledgementCodes.isValid(trimmed)) {
                 throw new IllegalArgumentException(String.format(
                         "Code d'accusé de réception '%s' invalide. Référez-vous à la liste UNECE : %s",
                         trimmed,
-                        DocumentStatusCodes.validCodes()));
+                        AcknowledgementCodes.validCodes()));
             }
             this.acknowledgementCode = trimmed;
             return this;

--- a/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/OrderResponseGenerator.java
+++ b/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/OrderResponseGenerator.java
@@ -9,7 +9,7 @@ import com.cii.messaging.unece.orderresponse.DateTimeType;
 import com.cii.messaging.unece.orderresponse.DocumentCodeType;
 import com.cii.messaging.unece.orderresponse.DocumentContextParameterType;
 import com.cii.messaging.unece.orderresponse.DocumentLineDocumentType;
-import com.cii.messaging.unece.orderresponse.DocumentStatusCodeType;
+import com.cii.messaging.unece.orderresponse.MessageFunctionCodeType;
 import com.cii.messaging.unece.orderresponse.ExchangedDocumentContextType;
 import com.cii.messaging.unece.orderresponse.ExchangedDocumentType;
 import com.cii.messaging.unece.orderresponse.HeaderTradeAgreementType;
@@ -192,10 +192,10 @@ public final class OrderResponseGenerator {
             typeCode.setListAgencyID("6");
             document.setTypeCode(typeCode);
 
-            DocumentStatusCodeType statusCode = new DocumentStatusCodeType();
-            statusCode.setValue(options.getAcknowledgementCode());
-            statusCode.setListAgencyID("6");
-            document.setStatusCode(statusCode);
+            MessageFunctionCodeType purposeCode = new MessageFunctionCodeType();
+            purposeCode.setValue(options.getAcknowledgementCode());
+            purposeCode.setListAgencyID("6");
+            document.setPurposeCode(purposeCode);
 
             DateTimeType dateTime = new DateTimeType();
             DateTimeType.DateTimeString dateTimeString = new DateTimeType.DateTimeString();

--- a/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/generation/AcknowledgementCodesTest.java
+++ b/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/generation/AcknowledgementCodesTest.java
@@ -7,17 +7,17 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class DocumentStatusCodesTest {
+class AcknowledgementCodesTest {
 
     @Test
     void chargeCodesDepuisLeSchemaD23B() {
-        Set<String> codes = DocumentStatusCodes.validCodes();
+        Set<String> codes = AcknowledgementCodes.validCodes();
 
         assertFalse(codes.isEmpty(), "La liste des codes UNECE ne doit pas être vide");
-        assertTrue(codes.contains(DocumentStatusCodes.DEFAULT_ACKNOWLEDGEMENT_CODE),
+        assertTrue(codes.contains(AcknowledgementCodes.DEFAULT_ACKNOWLEDGEMENT_CODE),
                 "Le code par défaut doit être présent dans la liste");
         assertTrue(codes.contains("1"), "Le premier code de la nomenclature doit être disponible");
-        assertTrue(codes.contains("51"), "Le dernier code de la nomenclature D23B doit être disponible");
+        assertTrue(codes.contains("73"), "Le dernier code de la nomenclature D23B doit être disponible");
         assertFalse(codes.contains("0"), "Les valeurs hors nomenclature doivent être rejetées");
     }
 }

--- a/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/generation/OrderResponseGenerationOptionsTest.java
+++ b/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/generation/OrderResponseGenerationOptionsTest.java
@@ -11,7 +11,7 @@ class OrderResponseGenerationOptionsTest {
     void utiliseCodeParDefautConforme() {
         OrderResponseGenerationOptions options = OrderResponseGenerationOptions.defaults();
 
-        assertEquals(DocumentStatusCodes.DEFAULT_ACKNOWLEDGEMENT_CODE, options.getAcknowledgementCode());
+        assertEquals(AcknowledgementCodes.DEFAULT_ACKNOWLEDGEMENT_CODE, options.getAcknowledgementCode());
     }
 
     @Test
@@ -22,6 +22,6 @@ class OrderResponseGenerationOptionsTest {
                         .build());
 
         assertEquals("Code d'accusé de réception 'AP' invalide. Référez-vous à la liste UNECE : "
-                + DocumentStatusCodes.validCodes(), exception.getMessage());
+                        + AcknowledgementCodes.validCodes(), exception.getMessage());
     }
 }

--- a/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/generation/OrderResponseGeneratorTest.java
+++ b/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/generation/OrderResponseGeneratorTest.java
@@ -54,15 +54,15 @@ class OrderResponseGeneratorTest {
         OrderResponseGenerationOptions options = OrderResponseGenerationOptions.builder()
                 .withResponseIdPrefix("RSP-")
                 .withIssueDateTime(LocalDateTime.of(2024, 3, 5, 12, 0))
-                .withAcknowledgementCode(DocumentStatusCodes.DEFAULT_ACKNOWLEDGEMENT_CODE)
+                .withAcknowledgementCode(AcknowledgementCodes.DEFAULT_ACKNOWLEDGEMENT_CODE)
                 .build();
 
         OrderResponse response = OrderResponseGenerator.genererDepuisOrder(order, options);
 
         assertEquals("RSP-DOC-001", response.getExchangedDocument().getID().getValue());
-        assertEquals(DocumentStatusCodes.DEFAULT_ACKNOWLEDGEMENT_CODE,
-                response.getExchangedDocument().getStatusCode().getValue());
-        assertEquals("6", response.getExchangedDocument().getStatusCode().getListAgencyID());
+        assertEquals(AcknowledgementCodes.DEFAULT_ACKNOWLEDGEMENT_CODE,
+                response.getExchangedDocument().getPurposeCode().getValue());
+        assertEquals("6", response.getExchangedDocument().getPurposeCode().getListAgencyID());
         assertEquals("6", response.getExchangedDocument().getTypeCode().getListAgencyID());
         assertEquals("20240305",
                 response.getExchangedDocument().getIssueDateTime().getDateTimeString().getValue());


### PR DESCRIPTION
## Summary
- écrire le code d’accusé de réception ORDER_RESPONSE dans ExchangedDocument.PurposeCode
- valider les codes via la liste UNECE MessageFunctionCode et exposer l’option dans le CLI
- mettre à jour les tests de génération d’ORDER_RESPONSE avec la nouvelle source de codes

## Testing
- mvn -pl cii-writer -am test -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69296c4d87ac832eb9367f51db060c0c)