### PR TITLE
Add CLI option to control ORDER_RESPONSE line status codes

### DIFF
--- a/cii-messaging-parent/README.md
+++ b/cii-messaging-parent/README.md
@@ -135,17 +135,18 @@ Génère automatiquement un ORDER_RESPONSE (ORDERSP) à partir d’un ORDER exis
 | `--response-id <ID>` | Identifiant explicite du document ORDER_RESPONSE | Préfixe + ID de l’ORDER |
 | `--response-id-prefix <PREFIX>` | Préfixe utilisé pour générer l’ID si aucun n’est fourni | `ORDRSP-` |
 | `--ack-code <CODE>` | Code de fonction/objectif du message UN/CEFACT injecté dans ExchangedDocument/PurposeCode (1–51, ex. `29`=Accepté, `42`=Rejeté) | `29` |
+| `--line-status-code <CODE>` | Code UNECE **ActionCode/1229** appliqué à toutes les lignes (`LineStatusCode`), validé contre la liste officielle (ex. `3`=Changement, `5`=Accepté, `6`=Accepté avec modification, `7`=Rejeté, `10`=Non trouvé) | Valeur issue du ORDER |
 | `--issue-date <yyyyMMddHHmmss>` | Date d’émission forcée | Date courante |
 
 La commande lit le message ORDER, reconstruit les entêtes (parties, montants, lignes) et produit un ORDER_RESPONSE
-cohérent avec les quantités demandées.Le code d’accusé de réception est inscrit dans CrossIndustryOrderResponse/ExchangedDocument/PurposeCode en utilisant la liste officielle des Codes de Fonction/Objectif de Message UN/CEFACT.
+cohérent avec les quantités demandées. Le code d’accusé de réception est inscrit dans `CrossIndustryOrderResponse/ExchangedDocument/PurposeCode` en utilisant la liste officielle des Codes de Fonction/Objectif de Message UN/CEFACT. L’option `--line-status-code` force également `CrossIndustryOrderResponse/SupplyChainTradeTransaction/IncludedSupplyChainTradeLineItem/AssociatedDocumentLineDocument/LineStatusCode` pour chaque ligne en vérifiant que la valeur figure dans la liste UNECE (ActionCode/1229).
 
 Generated XML now declares the canonical CII prefixes (`rsm`, `ram`, `udt`, `qdt`) so that CLI outputs match UNECE interoperability requirements.
 
 ```bash
 # Générer une réponse acceptée pour order-sample.xml et l’écrire dans target/order-response.xml
 java -jar cii-cli/target/cii-cli-1.0.0-SNAPSHOT-jar-with-dependencies.jar \
-  respond --ack-code 29 --response-id-prefix ORDRSP- \
+  respond --ack-code 29 --response-id-prefix ORDRSP- --line-status-code 5 \
   --output target/order-response.xml cii-samples/src/main/resources/samples/order-sample.xml
 ```
 
@@ -233,11 +234,19 @@ complète des valeurs officielles à utiliser dans vos ORDER_RESPONSE (`ORDRSP`)
 
 Pour les réponses aux commandes **AMAZON**, le chemin XML
 `CrossIndustryOrderResponse/SupplyChainTradeTransaction/IncludedSupplyChainTradeLineItem/AssociatedDocumentLineDocument/LineStatusCode`
-doit véhiculer des codes spécifiques pour indiquer le statut de chaque ligne lors de l’envoi d’un message **OrderResponse (ORDRSP)** :
+doit véhiculer des codes spécifiques pour indiquer le statut de chaque ligne lors de l’envoi d’un message **OrderResponse (ORDRSP)**. La CLI vérifie la conformité des valeurs avec la liste officielle **UN/CEFACT ActionCode (1229)** extraite du schéma UNECE et accepte toute valeur publiée (1 à 119). Les codes les plus courants sont :
 
-- **3 – Changement** : La ligne est modifiée par rapport à la demande initiale.
-- **5 – Accepté** : La ligne est acceptée telle que demandée.
-- **10 – Non trouvé** : La ligne référencée n’a pas été identifiée dans la commande.
+| Code | Signification (fr) | Usage typique |
+|------|---------------------|---------------|
+| `1` | Ajout d’une ligne nouvelle | Ajout d’un article non présent initialement |
+| `2` | Suppression/annulation d’une ligne | Retrait complet de l’article demandé |
+| `3` | Changement | Ligne modifiée par rapport à la commande d’origine |
+| `5` | Accepté sans modification | Ligne acceptée telle que demandée |
+| `6` | Accepté avec modification | Ligne acceptée avec ajustements (quantité, date, prix, etc.) |
+| `7` | Rejeté / non accepté | Ligne refusée |
+| `10` | Ligne non trouvée | Identifiant de ligne introuvable dans la commande |
+
+Référez-vous à la publication officielle UN/CEFACT pour la liste exhaustive : <https://service.unece.org/trade/uncefact/publication/SupplyChainMGMT/CIOP/CIOR/HTML/001.htm>.
 
 
 ## 🧪 Exemples en ligne de commande

--- a/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/RespondCommand.java
+++ b/cii-messaging-parent/cii-cli/src/main/java/com/cii/messaging/cli/RespondCommand.java
@@ -50,6 +50,10 @@ public class RespondCommand extends AbstractCommand implements Callable<Integer>
     @Option(names = "--response-id-prefix", description = "Préfixe appliqué à l'identifiant si non fourni", defaultValue = "ORDRSP-")
     private String responseIdPrefix = "ORDRSP-";
 
+    @Option(names = "--line-status-code",
+            description = "Code UNECE ActionCode/1229 appliqué à toutes les lignes (ex: 3=Changement, 5=Accepté, 10=Non trouvé)")
+    private String lineStatusCode;
+
     @Override
     public Integer call() {
         configureLogging();
@@ -100,6 +104,9 @@ public class RespondCommand extends AbstractCommand implements Callable<Integer>
         }
         if (issueDate != null && !issueDate.isBlank()) {
             builder.withIssueDateTime(LocalDateTime.parse(issueDate.trim(), ISSUE_DATE_FORMAT));
+        }
+        if (lineStatusCode != null && !lineStatusCode.isBlank()) {
+            builder.withLineStatusCode(lineStatusCode);
         }
         return builder.build();
     }

--- a/cii-messaging-parent/cii-cli/src/test/java/com/cii/messaging/cli/RespondCommandTest.java
+++ b/cii-messaging-parent/cii-cli/src/test/java/com/cii/messaging/cli/RespondCommandTest.java
@@ -43,6 +43,26 @@ class RespondCommandTest {
     }
 
     @Test
+    void appliqueUnLineStatusCodeSpecifie() throws Exception {
+        Path input = copierEchantillon("/order-sample.xml");
+        Path output = tempDir.resolve("ordersp.xml");
+
+        int exitCode = new CommandLine(new RespondCommand()).execute(
+                input.toString(),
+                "--output", output.toString(),
+                "--line-status-code", "3",
+                "--issue-date", "20240305120000"
+        );
+
+        assertThat(exitCode).isZero();
+
+        OrderResponse response = lireOrderResponse(output);
+        assertThat(response.getSupplyChainTradeTransaction().getIncludedSupplyChainTradeLineItem())
+                .allSatisfy(line -> assertThat(line.getAssociatedDocumentLineDocument().getLineStatusCode().getValue())
+                        .isEqualTo("3"));
+    }
+
+    @Test
     void genereFichierParDefautDansMemeDossier() throws Exception {
         Path input = copierEchantillon("/order-sample.xml");
 

--- a/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/LineStatusCodes.java
+++ b/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/LineStatusCodes.java
@@ -1,0 +1,116 @@
+package com.cii.messaging.writer.generation;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Référentiel des codes UNECE (ActionCode/1229) utilisables pour {@code LineStatusCode}.
+ *
+ * <p>La liste est chargée depuis le jeu de codes UNECE embarqué afin de rester synchronisée avec
+ * le standard. En cas d'indisponibilité du fichier XSD, un repli complet (1..119) est proposé.</p>
+ */
+public final class LineStatusCodes {
+
+    private static final String ACTION_CODE_RESOURCE =
+            "/xsd/D23B/CrossIndustryOrderResponse_100pD23B_urn_un_unece_uncefact_codelist_standard_"
+                    + "UNECE_ActionCode_D23A.xsd";
+    private static final Set<String> VALID_CODES;
+    private static final Set<String> FALLBACK_CODES = buildFallbackCodes();
+
+    static {
+        VALID_CODES = loadCodes();
+    }
+
+    private LineStatusCodes() {
+        // utilitaire
+    }
+
+    /**
+     * Vérifie si le code fourni appartient au référentiel ActionCode (1229) UNECE.
+     *
+     * @param code valeur candidate (peut être {@code null})
+     * @return {@code true} si le code est reconnu
+     */
+    public static boolean isValid(String code) {
+        return code != null && VALID_CODES.contains(code);
+    }
+
+    /**
+     * Liste immuable des codes valides afin de documenter les messages d'erreur.
+     *
+     * @return ensemble des codes disponibles
+     */
+    public static Set<String> validCodes() {
+        return VALID_CODES;
+    }
+
+    private static Set<String> loadCodes() {
+        try (InputStream stream = LineStatusCodes.class.getResourceAsStream(ACTION_CODE_RESOURCE)) {
+            if (stream == null) {
+                return FALLBACK_CODES;
+            }
+
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setNamespaceAware(true);
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            disableExternalEntities(factory);
+
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            Document document = builder.parse(stream);
+            NodeList nodes = document.getElementsByTagNameNS(XMLConstants.W3C_XML_SCHEMA_NS_URI, "enumeration");
+            if (nodes == null || nodes.getLength() == 0) {
+                return FALLBACK_CODES;
+            }
+
+            Set<String> codes = new LinkedHashSet<>();
+            for (int i = 0; i < nodes.getLength(); i++) {
+                String value = nodes.item(i).getAttributes().getNamedItem("value").getNodeValue();
+                if (value != null && !value.isBlank()) {
+                    codes.add(value.trim());
+                }
+            }
+            return Collections.unmodifiableSet(codes);
+        } catch (ParserConfigurationException e) {
+            throw new IllegalStateException("Impossible d'initialiser le parseur XML pour les codes d'état de ligne", e);
+        } catch (SAXException e) {
+            throw new IllegalStateException("Fichier XSD UNECE invalide pour les codes d'état de ligne", e);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Impossible de lire la liste des codes d'état de ligne UNECE", e);
+        }
+    }
+
+    private static void disableExternalEntities(DocumentBuilderFactory factory) {
+        try {
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        } catch (IllegalArgumentException ignored) {
+            // propriété non supportée selon l'implémentation
+        }
+        try {
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        } catch (IllegalArgumentException ignored) {
+            // idem
+        }
+    }
+
+    private static Set<String> buildFallbackCodes() {
+        Set<String> codes = IntStream.rangeClosed(1, 119)
+                .mapToObj(String::valueOf)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        return Collections.unmodifiableSet(codes);
+    }
+}

--- a/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/OrderResponseGenerationOptions.java
+++ b/cii-messaging-parent/cii-writer/src/main/java/com/cii/messaging/writer/generation/OrderResponseGenerationOptions.java
@@ -13,6 +13,7 @@ public final class OrderResponseGenerationOptions {
     private final String responseIdPrefix;
     private final String acknowledgementCode;
     private final String documentTypeCode;
+    private final String lineStatusCode;
     private final LocalDateTime issueDateTime;
     private final Clock clock;
 
@@ -21,6 +22,7 @@ public final class OrderResponseGenerationOptions {
         this.responseIdPrefix = builder.responseIdPrefix;
         this.acknowledgementCode = builder.acknowledgementCode;
         this.documentTypeCode = builder.documentTypeCode;
+        this.lineStatusCode = builder.lineStatusCode;
         this.issueDateTime = builder.issueDateTime;
         this.clock = builder.clock;
     }
@@ -80,6 +82,16 @@ public final class OrderResponseGenerationOptions {
     }
 
     /**
+     * Code de statut de ligne UNECE (ActionCode/1229) à appliquer à chaque ligne.
+     * Lorsque {@code null}, le statut de la commande source est conservé.
+     *
+     * @return code optionnel ou {@code null}
+     */
+    public String getLineStatusCode() {
+        return lineStatusCode;
+    }
+
+    /**
      * Date d'émission explicite. Si {@code null}, l'horloge est utilisée.
      *
      * @return date d'émission souhaitée ou {@code null}
@@ -105,6 +117,7 @@ public final class OrderResponseGenerationOptions {
         private String responseIdPrefix = "ORDRSP-";
         private String acknowledgementCode = AcknowledgementCodes.DEFAULT_ACKNOWLEDGEMENT_CODE;
         private String documentTypeCode = "231";
+        private String lineStatusCode;
         private LocalDateTime issueDateTime;
         private Clock clock = Clock.systemUTC();
 
@@ -162,6 +175,31 @@ public final class OrderResponseGenerationOptions {
          */
         public Builder withDocumentTypeCode(String documentTypeCode) {
             this.documentTypeCode = Objects.requireNonNull(documentTypeCode, "documentTypeCode");
+            return this;
+        }
+
+        /**
+         * Force un code de statut de ligne (ActionCode/1229) pour toutes les lignes générées.
+         *
+         * @param lineStatusCode code valide ou {@code null} pour conserver la valeur source
+         * @return builder pour chaînage
+         */
+        public Builder withLineStatusCode(String lineStatusCode) {
+            if (lineStatusCode == null) {
+                this.lineStatusCode = null;
+                return this;
+            }
+            String trimmed = lineStatusCode.trim();
+            if (trimmed.isEmpty()) {
+                throw new IllegalArgumentException("Le code de statut de ligne ne peut pas être vide");
+            }
+            if (!LineStatusCodes.isValid(trimmed)) {
+                throw new IllegalArgumentException(String.format(
+                        "Code de statut de ligne '%s' invalide. Référez-vous à la liste UNECE : %s",
+                        trimmed,
+                        LineStatusCodes.validCodes()));
+            }
+            this.lineStatusCode = trimmed;
             return this;
         }
 

--- a/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/generation/OrderResponseGenerationOptionsTest.java
+++ b/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/generation/OrderResponseGenerationOptionsTest.java
@@ -24,4 +24,24 @@ class OrderResponseGenerationOptionsTest {
         assertEquals("Code d'accusé de réception 'AP' invalide. Référez-vous à la liste UNECE : "
                         + AcknowledgementCodes.validCodes(), exception.getMessage());
     }
+
+    @Test
+    void accepteUnLineStatusCodeValide() {
+        OrderResponseGenerationOptions options = OrderResponseGenerationOptions.builder()
+                .withLineStatusCode("5")
+                .build();
+
+        assertEquals("5", options.getLineStatusCode());
+    }
+
+    @Test
+    void rejetteUnLineStatusCodeInvalide() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+                OrderResponseGenerationOptions.builder()
+                        .withLineStatusCode("999")
+                        .build());
+
+        assertEquals("Code de statut de ligne '999' invalide. Référez-vous à la liste UNECE : "
+                        + LineStatusCodes.validCodes(), exception.getMessage());
+    }
 }

--- a/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/generation/OrderResponseGeneratorTest.java
+++ b/cii-messaging-parent/cii-writer/src/test/java/com/cii/messaging/writer/generation/OrderResponseGeneratorTest.java
@@ -136,6 +136,23 @@ class OrderResponseGeneratorTest {
         assertEquals(statusCode, lineItem.getAssociatedDocumentLineDocument().getLineStatusCode().getValue());
     }
 
+    @Test
+    void surchargeLeLineStatusCodeDepuisLesOptions() {
+        Order order = buildOrderWithStatus("5");
+
+        OrderResponse response = OrderResponseGenerator.genererDepuisOrder(order,
+                OrderResponseGenerationOptions.builder()
+                        .withIssueDateTime(LocalDateTime.of(2024, 3, 5, 12, 0))
+                        .withLineStatusCode("3")
+                        .build());
+
+        com.cii.messaging.unece.orderresponse.SupplyChainTradeLineItemType lineItem = response
+                .getSupplyChainTradeTransaction().getIncludedSupplyChainTradeLineItem().get(0);
+
+        assertEquals("3", lineItem.getAssociatedDocumentLineDocument().getLineStatusCode().getValue());
+        assertEquals("6", lineItem.getAssociatedDocumentLineDocument().getLineStatusCode().getListAgencyID());
+    }
+
     private static Order buildOrder() {
         Order order = new Order();
 


### PR DESCRIPTION
## Summary
- add UNECE ActionCode loader and validation for LineStatusCode overrides
- extend ORDER_RESPONSE generation options and CLI respond command with --line-status-code
- document Amazon LineStatusCode usage and new CLI option in README

## Testing
- mvn -pl cii-cli -am test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69298d2f3620832e937a7be562fd0ef3)